### PR TITLE
Declare `Automatic-Module-Name` in preparation for java 9.

### DIFF
--- a/context-propagation-java5/pom.xml
+++ b/context-propagation-java5/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <maven.compiler.source>1.5</maven.compiler.source>
         <maven.compiler.target>1.5</maven.compiler.target>
+        <project.moduleName>${project.groupId}</project.moduleName>
         <root.basedir>${project.parent.basedir}</root.basedir>
         <javax.annotation-api.version>1.3.1</javax.annotation-api.version>
     </properties>

--- a/context-propagation-java8/pom.xml
+++ b/context-propagation-java8/pom.xml
@@ -31,6 +31,7 @@
     <packaging>jar</packaging>
 
     <properties>
+        <project.moduleName>${project.groupId}.java8</project.moduleName>
         <root.basedir>${project.parent.basedir}</root.basedir>
     </properties>
 

--- a/locale-context/pom.xml
+++ b/locale-context/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <maven.compiler.source>1.5</maven.compiler.source>
         <maven.compiler.target>1.5</maven.compiler.target>
+        <project.moduleName>${project.groupId}.locale</project.moduleName>
         <root.basedir>${project.parent.basedir}</root.basedir>
     </properties>
 

--- a/mdc-propagation/pom.xml
+++ b/mdc-propagation/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <maven.compiler.source>1.5</maven.compiler.source>
         <maven.compiler.target>1.5</maven.compiler.target>
+        <project.moduleName>${project.groupId}.mdc</project.moduleName>
         <root.basedir>${project.parent.basedir}</root.basedir>
     </properties>
 

--- a/opentracing-span-propagation/pom.xml
+++ b/opentracing-span-propagation/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
+        <project.moduleName>${project.groupId}.opentracing</project.moduleName>
         <root.basedir>${project.parent.basedir}</root.basedir>
         <opentracing-api.version>0.31.0</opentracing-api.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.moduleName>${project.groupId}.${project.artifactId}</project.moduleName>
         <root.basedir>${project.basedir}</root.basedir>
 
         <slf4j.version>1.7.25</slf4j.version>
@@ -91,6 +92,7 @@
         <maven-failsafe-plugin.version>2.20.1</maven-failsafe-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.0.0</maven-javadoc-plugin.version>
+        <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-scm-plugin.version>1.9.5</maven-scm-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
@@ -165,6 +167,18 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven-jar-plugin.version}</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${project.moduleName}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/servletrequest-propagation/pom.xml
+++ b/servletrequest-propagation/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <maven.compiler.source>1.5</maven.compiler.source>
         <maven.compiler.target>1.5</maven.compiler.target>
+        <project.moduleName>${project.groupId}.servletrequest</project.moduleName>
         <root.basedir>${project.parent.basedir}</root.basedir>
     </properties>
 


### PR DESCRIPTION
See https://github.com/talsma-ict/enumerables/pull/53 for a similar PR and explanation
(or read [this blog post](http://branchandbound.net/blog/java/2017/12/automatic-module-name/)).