### PR TITLE
Add a way to clear all managed contexts

### DIFF
--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/ContextManagers.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/ContextManagers.java
@@ -98,10 +98,28 @@ public final class ContextManagers {
     }
 
     /**
+     * Clears all managed contexts from the current thread.
+     * <p>
+     * Contexts that are 'stacked' (i.e. restore the previous state upon close) should be
+     * closed in a way that includes all 'parent' contexts as well.
+     * <p>
+     * This operation is not intended to be used by general application code as it breaks any current context stack
+     * that surrounding code may depend upon.
+     * Appropriate use includes thread management, where threads can be reused by some pooling
+     * mechanism. For example, it is considered safe to clear the context when obtaining a 'fresh' thread from a
+     * thread pool (as no context expectations should exist at that point). It would be even better to clear the
+     * context just before returning a used thread to the pool as this will allow any unclosed contexts to be
+     * garbage collected and reduces the risk of memory leaks.
+     */
+    public static void clearManagedContexts() {
+        throw new UnsupportedOperationException("Clearing all managed contexts is currently under development.");
+    }
+
+    /**
      * Implementation of the <code>createContextSnapshot</code> functionality that can reactivate all values from the
      * snapshot in each corresponding {@link ContextManager}.
      * <p>
-     * This class is only really {@link Serializable} if all captured {@link Context#getValue() values} actually are
+     * This class is only really {@link Serializable} if all captured {@link Context#getValue() values} are
      * serializable as well. The {@link ContextManager} implementations do not need to be {@link Serializable}.
      */
     private static final class ContextSnapshotImpl implements ContextSnapshot, Serializable {

--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/ContextManagers.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/ContextManagers.java
@@ -105,7 +105,7 @@ public final class ContextManagers {
      * Contexts that are 'stacked' (i.e. restore the previous state upon close) should be
      * closed in a way that includes all 'parent' contexts as well.
      * <p>
-     * This operation is not intended to be used by general application code as likely breaks any 'stacked'
+     * This operation is not intended to be used by general application code as it likely breaks any 'stacked'
      * active context that surrounding code may depend upon.
      * Appropriate use includes thread management, where threads are reused by some pooling
      * mechanism. For example, it is considered safe to clear the context when obtaining a 'fresh' thread from a

--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/clearable/Clearable.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/clearable/Clearable.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016-2018 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.context.clearable;
+
+/**
+ * Interface that marks an to be 'clearable'.
+ * <p>
+ * Context managers that support clearing the active context for the current thread
+ * should implement the {@link Clearable} interface.
+ * <p>
+ * Clearing the context removes not only an active context from the current thread,
+ * but also the potential stack of any parents.
+ * This operation is intended to only be used when re-using threads (e.g. when returning them to a thread-pool).
+ *
+ * @author Sjoerd Talsma
+ */
+public interface Clearable {
+
+    /**
+     * Clears the current context and any potential parent contexts that may be stacked.
+     */
+    void clear();
+
+}

--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/clearable/ClearableContextManager.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/clearable/ClearableContextManager.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016-2018 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.context.clearable;
+
+import nl.talsmasoftware.context.ContextManager;
+
+/**
+ * Convenience interface to mark a {@linkplain Clearable} {@link ContextManager}.
+ *
+ * @author Sjoerd Talsma
+ */
+public interface ClearableContextManager<T> extends ContextManager<T>, Clearable {
+}

--- a/context-propagation-java5/src/test/java/nl/talsmasoftware/context/ContextManagersTest.java
+++ b/context-propagation-java5/src/test/java/nl/talsmasoftware/context/ContextManagersTest.java
@@ -262,4 +262,15 @@ public class ContextManagersTest {
             assertThat("Restore service file!", TMP_SERVICE_FILE.renameTo(SERVICE_FILE), is(true));
         }
     }
+
+    @Test
+    public void testClearManagedContexts_withoutContextManagers() {
+        assertThat("Move service file", SERVICE_FILE.renameTo(TMP_SERVICE_FILE), is(true));
+        try {
+            ContextManagers.clearActiveContexts();
+            // there should be no exception
+        } finally {
+            assertThat("Restore service file!", TMP_SERVICE_FILE.renameTo(SERVICE_FILE), is(true));
+        }
+    }
 }

--- a/context-propagation-java5/src/test/java/nl/talsmasoftware/context/ContextSnapshotTest.java
+++ b/context-propagation-java5/src/test/java/nl/talsmasoftware/context/ContextSnapshotTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
 
 /**
  * @author Sjoerd Talsma
@@ -32,7 +33,7 @@ public class ContextSnapshotTest {
     public void testSnapshotToString() {
         Context<String> ctx = MGR.initializeNewContext("Dummy value");
         try {
-            assertThat(ContextManagers.createContextSnapshot(), hasToString("ContextSnapshot{size=1}"));
+            assertThat(ContextManagers.createContextSnapshot(), hasToString(startsWith("ContextSnapshot{size=")));
         } finally {
             ctx.close();
         }
@@ -51,7 +52,7 @@ public class ContextSnapshotTest {
                 try {
                     assertThat(MGR.getActiveContext().getValue(), is("Old value"));
                     assertThat(reactivation.getValue(), is(nullValue()));
-                    assertThat(reactivation, hasToString("ReactivatedContext{size=1}"));
+                    assertThat(reactivation, hasToString(startsWith("ReactivatedContext{size=")));
                 } finally {
                     reactivation.close();
                 }

--- a/context-propagation-java5/src/test/java/nl/talsmasoftware/context/ThrowingContextManager.java
+++ b/context-propagation-java5/src/test/java/nl/talsmasoftware/context/ThrowingContextManager.java
@@ -23,7 +23,7 @@ import nl.talsmasoftware.context.threadlocal.AbstractThreadLocalContext;
  * @author Sjoerd Talsma
  */
 public class ThrowingContextManager implements ContextManager<String> {
-    static RuntimeException inConstructor = null, onInitialize = null, onGet = null;
+    public static RuntimeException inConstructor = null, onInitialize = null, onGet = null;
 
     public ThrowingContextManager() {
         if (inConstructor != null) try {

--- a/context-propagation-java5/src/test/java/nl/talsmasoftware/context/clearable/AutoInitializingContextManager.java
+++ b/context-propagation-java5/src/test/java/nl/talsmasoftware/context/clearable/AutoInitializingContextManager.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016-2018 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.context.clearable;
+
+import nl.talsmasoftware.context.Context;
+import nl.talsmasoftware.context.ContextManager;
+
+public class AutoInitializingContextManager implements ContextManager<String> {
+    private static final ThreadLocal<DummyContext> CTX = new ThreadLocal<DummyContext>() {
+        @Override
+        protected DummyContext initialValue() {
+            return new DummyContext(null, null);
+        }
+    };
+
+    public Context<String> getActiveContext() {
+        return CTX.get();
+    }
+
+    public Context<String> initializeNewContext(String value) {
+        CTX.set(new DummyContext(CTX.get(), value));
+        return CTX.get();
+    }
+
+    private static class DummyContext implements Context<String> {
+        private final DummyContext previous;
+        private String value;
+
+        private DummyContext(DummyContext previous, String value) {
+            this.previous = previous;
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        /**
+         * Only for testing! DO NOT COPY! This is not a safe implementation.
+         * <p>
+         * Please see AbstractThreadLocalContext for reference code if you wish manage a stack of contexts!
+         */
+        public void close() {
+            if (previous == null) CTX.remove();
+            else CTX.set(previous);
+            this.value = null;
+        }
+    }
+}

--- a/context-propagation-java5/src/test/java/nl/talsmasoftware/context/clearable/ClearableContextManagerTest.java
+++ b/context-propagation-java5/src/test/java/nl/talsmasoftware/context/clearable/ClearableContextManagerTest.java
@@ -15,8 +15,17 @@
  */
 package nl.talsmasoftware.context.clearable;
 
+import nl.talsmasoftware.context.ContextManager;
 import nl.talsmasoftware.context.ContextManagers;
+import nl.talsmasoftware.context.DummyContextManager;
+import nl.talsmasoftware.context.ThrowingContextManager;
 import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  * Tests for clearing context managers.
@@ -24,10 +33,69 @@ import org.junit.Test;
  * @author Sjoerd Talsma
  */
 public class ClearableContextManagerTest {
+    private static ContextManager<String> CLEARABLE = new ClearableDummyContextManager();
+    private static ContextManager<String> CONTEXT_CLEARABLE = new DummyManagerOfClearableContext();
+    private static ContextManager<String> AUTO_INITIALIZING = new AutoInitializingContextManager();
+    private static ContextManager<String> MANAGER_OF_ABSTRACTTLC = new DummyContextManager();
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void testUnsupportedBehaviour() {
-        ContextManagers.clearManagedContexts();
+    @Test
+    public void testClearActiveContexts_byManager() {
+        assertThat(CLEARABLE, is(instanceOf(Clearable.class)));
+
+        CLEARABLE.initializeNewContext("First value");
+        CLEARABLE.initializeNewContext("Second value");
+        CLEARABLE.initializeNewContext("Third value");
+        assertThat(CLEARABLE.getActiveContext().getValue(), is("Third value"));
+
+        ContextManagers.clearActiveContexts();
+        assertThat(CLEARABLE.getActiveContext(), is(nullValue()));
     }
 
+    @Test
+    public void testClearActiveContexts_byClearableContext() {
+        assertThat(CONTEXT_CLEARABLE, is(not(instanceOf(Clearable.class))));
+
+        CONTEXT_CLEARABLE.initializeNewContext("First value");
+        CONTEXT_CLEARABLE.initializeNewContext("Second value");
+        CONTEXT_CLEARABLE.initializeNewContext("Third value");
+        assertThat(CONTEXT_CLEARABLE.getActiveContext(), is(instanceOf(Clearable.class)));
+        assertThat(CONTEXT_CLEARABLE.getActiveContext().getValue(), is("Third value"));
+
+        ContextManagers.clearActiveContexts();
+        assertThat(CONTEXT_CLEARABLE.getActiveContext(), is(nullValue()));
+    }
+
+    @Test
+    public void testClearActiveContexts_byAbstractTLC() {
+        assertThat(MANAGER_OF_ABSTRACTTLC, is(not(instanceOf(Clearable.class))));
+
+        MANAGER_OF_ABSTRACTTLC.initializeNewContext("First value");
+        MANAGER_OF_ABSTRACTTLC.initializeNewContext("Second value");
+        MANAGER_OF_ABSTRACTTLC.initializeNewContext("Third value");
+        assertThat(MANAGER_OF_ABSTRACTTLC.getActiveContext().getValue(), is("Third value"));
+
+        ContextManagers.clearActiveContexts();
+        assertThat(MANAGER_OF_ABSTRACTTLC.getActiveContext(), is(nullValue()));
+    }
+
+    @Test
+    public void testClearActiveContexts_autoReinitializeNewContext() {
+        assertThat(AUTO_INITIALIZING, is(not(instanceOf(Clearable.class))));
+
+        AUTO_INITIALIZING.initializeNewContext("First value");
+        AUTO_INITIALIZING.initializeNewContext("Second value");
+        AUTO_INITIALIZING.initializeNewContext("Third value");
+        assertThat(AUTO_INITIALIZING.getActiveContext().getValue(), is("Third value"));
+
+        ContextManagers.clearActiveContexts();
+        assertThat(AUTO_INITIALIZING.getActiveContext().getValue(), is(nullValue()));
+    }
+
+    @Test
+    public void testClearActiveContexts_exception() {
+        ThrowingContextManager.onGet = new IllegalStateException("Cannot get the current active context!");
+
+        ContextManagers.clearActiveContexts();
+        // Mustn't throw exceptions.
+    }
 }

--- a/context-propagation-java5/src/test/java/nl/talsmasoftware/context/clearable/ClearableContextManagerTest.java
+++ b/context-propagation-java5/src/test/java/nl/talsmasoftware/context/clearable/ClearableContextManagerTest.java
@@ -15,11 +15,16 @@
  */
 package nl.talsmasoftware.context.clearable;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import nl.talsmasoftware.context.ContextManager;
 import nl.talsmasoftware.context.ContextManagers;
 import nl.talsmasoftware.context.DummyContextManager;
 import nl.talsmasoftware.context.ThrowingContextManager;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
@@ -37,6 +42,17 @@ public class ClearableContextManagerTest {
     private static ContextManager<String> CONTEXT_CLEARABLE = new DummyManagerOfClearableContext();
     private static ContextManager<String> AUTO_INITIALIZING = new AutoInitializingContextManager();
     private static ContextManager<String> MANAGER_OF_ABSTRACTTLC = new DummyContextManager();
+
+    @BeforeClass
+    public static void initLogback() {
+        if (!SLF4JBridgeHandler.isInstalled()) {
+            /* Initialize SLF4J bridge. This re-routes logging through java.util.logging to SLF4J. */
+            java.util.logging.LogManager.getLogManager().reset();
+            SLF4JBridgeHandler.install();
+            LoggerFactory.getILoggerFactory();
+        }
+        ((Logger) LoggerFactory.getLogger(ContextManagers.class)).setLevel(Level.ALL);
+    }
 
     @Test
     public void testClearActiveContexts_byManager() {

--- a/context-propagation-java5/src/test/java/nl/talsmasoftware/context/clearable/ClearableContextManagerTest.java
+++ b/context-propagation-java5/src/test/java/nl/talsmasoftware/context/clearable/ClearableContextManagerTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016-2018 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.context.clearable;
+
+import nl.talsmasoftware.context.ContextManagers;
+import org.junit.Test;
+
+/**
+ * Tests for clearing context managers.
+ *
+ * @author Sjoerd Talsma
+ */
+public class ClearableContextManagerTest {
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testUnsupportedBehaviour() {
+        ContextManagers.clearManagedContexts();
+    }
+
+}

--- a/context-propagation-java5/src/test/java/nl/talsmasoftware/context/clearable/ClearableDummyContextManager.java
+++ b/context-propagation-java5/src/test/java/nl/talsmasoftware/context/clearable/ClearableDummyContextManager.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016-2018 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.context.clearable;
+
+import nl.talsmasoftware.context.Context;
+
+public class ClearableDummyContextManager implements ClearableContextManager<String> {
+    private static final ThreadLocal<DummyContext> CTX = new ThreadLocal<DummyContext>();
+
+    public Context<String> getActiveContext() {
+        return CTX.get();
+    }
+
+    public Context<String> initializeNewContext(String value) {
+        return new DummyContext(value);
+    }
+
+    public void clear() {
+        CTX.remove();
+    }
+
+    private static class DummyContext implements Context<String> {
+        private final DummyContext previous;
+        private String value;
+
+        private DummyContext(String value) {
+            this.previous = CTX.get();
+            this.value = value;
+            CTX.set(this);
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        /**
+         * Only for testing! DO NOT COPY! This is not a safe implementation.
+         * <p>
+         * Please see AbstractThreadLocalContext for reference code if you wish manage a stack of contexts!
+         */
+        public void close() {
+            CTX.set(previous);
+            this.value = null;
+        }
+    }
+}

--- a/context-propagation-java5/src/test/java/nl/talsmasoftware/context/clearable/DummyManagerOfClearableContext.java
+++ b/context-propagation-java5/src/test/java/nl/talsmasoftware/context/clearable/DummyManagerOfClearableContext.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016-2018 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.context.clearable;
+
+import nl.talsmasoftware.context.Context;
+import nl.talsmasoftware.context.ContextManager;
+
+public class DummyManagerOfClearableContext implements ContextManager<String> {
+    private static final ThreadLocal<DummyContext> CTX = new ThreadLocal<DummyContext>();
+
+    public Context<String> getActiveContext() {
+        return CTX.get();
+    }
+
+    public Context<String> initializeNewContext(String value) {
+        return new DummyContext(value);
+    }
+
+    private static class DummyContext implements Context<String>, Clearable {
+        private final DummyContext previous;
+        private String value;
+
+        private DummyContext(String value) {
+            this.previous = CTX.get();
+            this.value = value;
+            CTX.set(this);
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        /**
+         * Only for testing! DO NOT COPY! This is not a safe implementation.
+         * <p>
+         * Please see AbstractThreadLocalContext for reference code if you wish manage a stack of contexts!
+         */
+        public void close() {
+            CTX.set(previous);
+            this.value = null;
+        }
+
+        public void clear() {
+            CTX.remove();
+        }
+
+    }
+}

--- a/context-propagation-java5/src/test/resources/META-INF/services/nl.talsmasoftware.context.ContextManager
+++ b/context-propagation-java5/src/test/resources/META-INF/services/nl.talsmasoftware.context.ContextManager
@@ -1,2 +1,5 @@
 nl.talsmasoftware.context.DummyContextManager
 nl.talsmasoftware.context.ThrowingContextManager
+nl.talsmasoftware.context.clearable.AutoInitializingContextManager
+nl.talsmasoftware.context.clearable.ClearableDummyContextManager
+nl.talsmasoftware.context.clearable.DummyManagerOfClearableContext

--- a/locale-context/src/main/java/nl/talsmasoftware/context/locale/LocaleContext.java
+++ b/locale-context/src/main/java/nl/talsmasoftware/context/locale/LocaleContext.java
@@ -15,6 +15,7 @@
  */
 package nl.talsmasoftware.context.locale;
 
+import nl.talsmasoftware.context.clearable.Clearable;
 import nl.talsmasoftware.context.threadlocal.AbstractThreadLocalContext;
 
 import java.util.Locale;
@@ -31,7 +32,7 @@ import java.util.Locale;
  *
  * @author Sjoerd Talsma
  */
-final class LocaleContext extends AbstractThreadLocalContext<Locale> {
+final class LocaleContext extends AbstractThreadLocalContext<Locale> implements Clearable {
     /**
      * Instantiates a new context with the specified value.
      * The new context will be made the active context for the current thread.
@@ -67,10 +68,17 @@ final class LocaleContext extends AbstractThreadLocalContext<Locale> {
     }
 
     /**
+     * Clears all remembered locales from this thread.
+     */
+    public void clear() {
+        clearAll();
+    }
+
+    /**
      * Unconditionally clears the entire {@link LocaleContext}.
      * This can be useful when returning threads to a threadpool.
      */
-    static void clear() {
+    static void clearAll() {
         try {
             for (LocaleContext current = current(); current != null; current = current()) current.close();
         } finally {

--- a/locale-context/src/main/java/nl/talsmasoftware/context/locale/LocaleContextManager.java
+++ b/locale-context/src/main/java/nl/talsmasoftware/context/locale/LocaleContextManager.java
@@ -59,7 +59,7 @@ public final class LocaleContextManager implements ContextManager<Locale> {
      * This is useful for boundary filters, whose Threads may be returned to some threadpool.
      */
     public static void clear() {
-        LocaleContext.clear();
+        LocaleContext.clearAll();
     }
 
     /**

--- a/locale-context/src/test/java/nl/talsmasoftware/context/locale/LocaleContextManagerTest.java
+++ b/locale-context/src/test/java/nl/talsmasoftware/context/locale/LocaleContextManagerTest.java
@@ -16,16 +16,28 @@
 package nl.talsmasoftware.context.locale;
 
 import nl.talsmasoftware.context.Context;
+import nl.talsmasoftware.context.ContextManagers;
 import nl.talsmasoftware.context.executors.ContextAwareExecutorService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Locale;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  * @author Sjoerd Talsma
@@ -85,7 +97,23 @@ public class LocaleContextManagerTest {
     public void testClear() {
         Context<Locale> dutchCtx = manager.initializeNewContext(DUTCH);
         Context<Locale> englishCtx = manager.initializeNewContext(ENGLISH);
+
         LocaleContextManager.clear();
+        assertThat(manager.getActiveContext(), is(nullValue()));
+        assertThat(LocaleContextManager.getCurrentLocale(), is(nullValue()));
+
+        assertThat(((LocaleContext) englishCtx).isClosed(), is(true));
+        assertThat(((LocaleContext) dutchCtx).isClosed(), is(true));
+        assertThat(englishCtx.getValue(), equalTo(ENGLISH));
+        assertThat(dutchCtx.getValue(), equalTo(DUTCH));
+    }
+
+    @Test
+    public void testClearActiveContexts() {
+        Context<Locale> dutchCtx = manager.initializeNewContext(DUTCH);
+        Context<Locale> englishCtx = manager.initializeNewContext(ENGLISH);
+
+        ContextManagers.clearActiveContexts();
         assertThat(manager.getActiveContext(), is(nullValue()));
         assertThat(LocaleContextManager.getCurrentLocale(), is(nullValue()));
 

--- a/mdc-propagation/src/main/java/nl/talsmasoftware/context/mdc/MdcManager.java
+++ b/mdc-propagation/src/main/java/nl/talsmasoftware/context/mdc/MdcManager.java
@@ -17,6 +17,7 @@ package nl.talsmasoftware.context.mdc;
 
 import nl.talsmasoftware.context.Context;
 import nl.talsmasoftware.context.ContextManager;
+import nl.talsmasoftware.context.clearable.Clearable;
 import org.slf4j.MDC;
 
 import java.util.Map;
@@ -78,7 +79,7 @@ public class MdcManager implements ContextManager<Map<String, String>> {
         return getClass().getSimpleName();
     }
 
-    private static final class MdcContext implements Context<Map<String, String>> {
+    private static final class MdcContext implements Context<Map<String, String>>, Clearable {
         private final Map<String, String> previous, value;
         private final AtomicBoolean closed;
 
@@ -99,9 +100,14 @@ public class MdcManager implements ContextManager<Map<String, String>> {
             }
         }
 
+        public void clear() {
+            close();
+        }
+
         @Override
         public String toString() {
             return closed.get() ? "MdcContext{closed}" : "MdcContext" + (value == null ? "{}" : value);
         }
+
     }
 }

--- a/mdc-propagation/src/test/java/nl/talsmasoftware/context/mdc/MdcManagerTest.java
+++ b/mdc-propagation/src/test/java/nl/talsmasoftware/context/mdc/MdcManagerTest.java
@@ -109,4 +109,13 @@ public class MdcManagerTest {
             ctx.close();
         }
     }
+
+    @Test
+    public void testClearActiveContexts() {
+        MdcManager mgr = new MdcManager();
+        MDC.put("dummy", "value");
+        // Test no-op for MdcManager
+        ContextManagers.clearActiveContexts();
+        assertThat(MDC.get("dummy"), is("value"));
+    }
 }

--- a/opentracing-span-propagation/src/main/java/nl/talsmasoftware/context/opentracing/SpanManager.java
+++ b/opentracing-span-propagation/src/main/java/nl/talsmasoftware/context/opentracing/SpanManager.java
@@ -44,7 +44,8 @@ public class SpanManager implements ContextManager<Span> {
      */
     @Override
     public Context<Span> getActiveContext() {
-        return new ManagedSpan(GlobalTracer.get().activeSpan(), null);
+        Span activeSpan = GlobalTracer.get().activeSpan();
+        return activeSpan == null ? null : new ManagedSpan(activeSpan, null);
     }
 
     /**

--- a/opentracing-span-propagation/src/test/java/nl/talsmasoftware/context/opentracing/SpanManagerTest.java
+++ b/opentracing-span-propagation/src/test/java/nl/talsmasoftware/context/opentracing/SpanManagerTest.java
@@ -25,6 +25,7 @@ import io.opentracing.util.GlobalTracerTestUtil;
 import io.opentracing.util.ThreadLocalScopeManager;
 import nl.talsmasoftware.context.Context;
 import nl.talsmasoftware.context.ContextManager;
+import nl.talsmasoftware.context.ContextManagers;
 import nl.talsmasoftware.context.executors.ContextAwareExecutorService;
 import org.junit.After;
 import org.junit.Before;
@@ -214,5 +215,16 @@ public class SpanManagerTest {
 
         newContext.close();
         newContext.close();
+    }
+
+    @Test
+    public void testClearingAllContexts() {
+        Span span = mockTracer.buildSpan("test-span").start();
+        Scope scope = mockTracer.scopeManager().activate(span, false);
+        assertThat(new SpanManager().getActiveContext().getValue(), is(sameInstance(span)));
+
+        ContextManagers.clearActiveContexts();
+        // TODO Test after this is merged: https://github.com/opentracing/opentracing-java/pull/313
+//        assertThat(new SpanManager().getActiveContext(), is(nullValue()));
     }
 }

--- a/servletrequest-propagation/src/main/java/nl/talsmasoftware/context/servletrequest/ServletRequestContext.java
+++ b/servletrequest-propagation/src/main/java/nl/talsmasoftware/context/servletrequest/ServletRequestContext.java
@@ -16,76 +16,36 @@
 package nl.talsmasoftware.context.servletrequest;
 
 import nl.talsmasoftware.context.Context;
-import nl.talsmasoftware.context.threadlocal.AbstractThreadLocalContext;
 
 import javax.servlet.ServletRequest;
-import java.util.logging.Logger;
 
 /**
- * ThreadLocal context containing the current {@link ServletRequest}.
+ * Simple (unstacked) context using a Threadlocal containing the current {@link ServletRequest}.
  *
  * @author Sjoerd Talsma
  */
-final class ServletRequestContext extends AbstractThreadLocalContext<ServletRequest> {
-    private static final Logger LOGGER = Logger.getLogger(ServletRequestContext.class.getName());
+final class ServletRequestContext implements Context<ServletRequest> {
 
-    /**
-     * The ThreadLocal context containing the {@link ServletRequest}.
-     */
-    private static final ThreadLocal<ServletRequestContext> CONTEXT = threadLocalInstanceOf(ServletRequestContext.class);
+    private static final ThreadLocal<ServletRequestContext> CONTEXT = new ThreadLocal<ServletRequestContext>();
 
-    /**
-     * Creates a new context with the specified request.
-     * <p>
-     * The new context will be made the active context for the current thread.
-     *
-     * @param newValue The new value to become active in this new context
-     *                 (or <code>null</code> to register a new context with 'no value').
-     */
-    ServletRequestContext(ServletRequest newValue) {
-        super(newValue);
+    volatile ServletRequest servletRequest;
+
+    ServletRequestContext(ServletRequest servletRequest) {
+        this.servletRequest = servletRequest;
+        CONTEXT.set(this);
     }
 
-    /**
-     * The current servlet request context.
-     * <p>
-     * If no active {@link ServletRequest} is found, a 'dummy', already-closed context is returned.
-     *
-     * @return The context with the current ServletRequest.
-     * The context itself is non-<code>null</code>, but may contain a <code>null</code> value.
-     * @see #getValue()
-     */
     static Context<ServletRequest> current() {
-        final ServletRequestContext current = CONTEXT.get();
-        return current != null ? current : None.INSTANCE;
+        return CONTEXT.get();
     }
 
-    /**
-     * {@link #close()} restores the previous context, but clear() unconditionally removes the active context.
-     * <p>
-     * This is useful for boundary filters, whose Threads may be returned to some threadpool.
-     */
-    static void clear() {
-        CONTEXT.remove();
-        LOGGER.finest("Cleared ServletRequestContext stack.");
+    public ServletRequest getValue() {
+        return servletRequest;
     }
 
-    /**
-     * Dummy context containing no servlet request.
-     */
-    private static final class None implements Context<ServletRequest> {
-        private static final None INSTANCE = new None();
-
-        public ServletRequest getValue() {
-            return null;
-        }
-
-        public void close() {
-        }
-
-        @Override
-        public String toString() {
-            return "ServletRequestContext.None";
-        }
+    public void close() {
+        servletRequest = null;
+        CONTEXT.set(null);
     }
+
 }

--- a/servletrequest-propagation/src/main/java/nl/talsmasoftware/context/servletrequest/ServletRequestContextAsyncListener.java
+++ b/servletrequest-propagation/src/main/java/nl/talsmasoftware/context/servletrequest/ServletRequestContextAsyncListener.java
@@ -32,14 +32,14 @@ final class ServletRequestContextAsyncListener implements AsyncListener {
     }
 
     public void onComplete(AsyncEvent event) {
-        ServletRequestContext.clear();
+        ServletRequestContextManager.clear();
     }
 
     public void onTimeout(AsyncEvent event) {
-        ServletRequestContext.clear();
+        ServletRequestContextManager.clear();
     }
 
     public void onError(AsyncEvent event) {
-        ServletRequestContext.clear();
+        ServletRequestContextManager.clear();
     }
 }

--- a/servletrequest-propagation/src/main/java/nl/talsmasoftware/context/servletrequest/ServletRequestContextFilter.java
+++ b/servletrequest-propagation/src/main/java/nl/talsmasoftware/context/servletrequest/ServletRequestContextFilter.java
@@ -49,7 +49,7 @@ public class ServletRequestContextFilter implements Filter {
             chain.doFilter(request, response);
 
         } finally {
-            ServletRequestContext.clear(); // Make sure there are no requests returned to the HTTP threadpool.
+            ServletRequestContextManager.clear(); // Make sure there are no requests returned to the HTTP threadpool.
         }
     }
 

--- a/servletrequest-propagation/src/main/java/nl/talsmasoftware/context/servletrequest/ServletRequestContextManager.java
+++ b/servletrequest-propagation/src/main/java/nl/talsmasoftware/context/servletrequest/ServletRequestContextManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Talsma ICT
+ * Copyright 2016-2018 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,10 @@ public final class ServletRequestContextManager implements ContextManager<Servle
      * This is useful for boundary filters, whose Threads may be returned to some threadpool.
      */
     public static void clear() {
-        ServletRequestContext.clear();
+        Context<ServletRequest> current = ServletRequestContext.current();
+        if (current != null) {
+            current.close();
+        }
     }
 
     public String toString() {

--- a/servletrequest-propagation/src/test/java/nl/talsmasoftware/context/servletrequest/ServletRequestContextAsyncListenerTest.java
+++ b/servletrequest-propagation/src/test/java/nl/talsmasoftware/context/servletrequest/ServletRequestContextAsyncListenerTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016-2018 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.context.servletrequest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.AsyncContext;
+import javax.servlet.AsyncEvent;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class ServletRequestContextAsyncListenerTest {
+
+    ServletRequestContextAsyncListener subject;
+
+    AsyncEvent event;
+    AsyncContext mockContext;
+    ServletRequest mockRequest;
+    ServletResponse mockResponse;
+
+    @Before
+    public void setUp() {
+        ServletRequestContextManager.clear();
+        mockContext = mock(AsyncContext.class);
+        mockRequest = mock(ServletRequest.class);
+        mockResponse = mock(ServletResponse.class);
+        event = new AsyncEvent(mockContext, mockRequest, mockResponse);
+
+        subject = new ServletRequestContextAsyncListener();
+    }
+
+    @After
+    public void tearDown() {
+        ServletRequestContextManager.clear();
+        verifyNoMoreInteractions(mockContext, mockRequest, mockResponse);
+    }
+
+    @Test
+    public void testOnStart() {
+        assertThat(ServletRequestContextManager.currentServletRequest(), is(nullValue()));
+
+        subject.onStartAsync(event);
+        assertThat(ServletRequestContextManager.currentServletRequest(), is(sameInstance(mockRequest)));
+
+        verify(mockContext).addListener(eq(subject));
+    }
+
+    @Test
+    public void testOnComplete() {
+        new ServletRequestContext(mockRequest);
+        assertThat(ServletRequestContextManager.currentServletRequest(), is(sameInstance(mockRequest)));
+
+        subject.onComplete(event);
+        assertThat(ServletRequestContextManager.currentServletRequest(), is(nullValue()));
+    }
+
+    @Test
+    public void testOnTimeout() {
+        new ServletRequestContext(mockRequest);
+        assertThat(ServletRequestContextManager.currentServletRequest(), is(sameInstance(mockRequest)));
+
+        subject.onTimeout(event);
+        assertThat(ServletRequestContextManager.currentServletRequest(), is(nullValue()));
+    }
+
+    @Test
+    public void testOnError() {
+        new ServletRequestContext(mockRequest);
+        assertThat(ServletRequestContextManager.currentServletRequest(), is(sameInstance(mockRequest)));
+
+        subject.onError(event);
+        assertThat(ServletRequestContextManager.currentServletRequest(), is(nullValue()));
+    }
+
+}

--- a/servletrequest-propagation/src/test/java/nl/talsmasoftware/context/servletrequest/ServletRequestContextFilterTest.java
+++ b/servletrequest-propagation/src/test/java/nl/talsmasoftware/context/servletrequest/ServletRequestContextFilterTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2016-2018 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.context.servletrequest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.servlet.AsyncContext;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class ServletRequestContextFilterTest {
+
+    ServletRequestContextFilter subject;
+
+    ServletRequest mockRequest;
+    ServletResponse mockResponse;
+    FilterConfig mockConfig;
+
+    @Before
+    public void setUp() {
+        mockRequest = mock(ServletRequest.class);
+        mockResponse = mock(ServletResponse.class);
+        mockConfig = mock(FilterConfig.class);
+
+        subject = new ServletRequestContextFilter();
+        subject.init(mockConfig);
+    }
+
+    @After
+    public void tearDown() {
+        subject.destroy();
+        verifyNoMoreInteractions(mockRequest, mockResponse, mockConfig);
+    }
+
+    @Test
+    public void testToString() {
+        assertThat(subject, hasToString(ServletRequestContextFilter.class.getSimpleName()));
+    }
+
+    @Test
+    public void testSimpleFiltering() throws IOException, ServletException {
+        when(mockRequest.isAsyncStarted()).thenReturn(false);
+
+        subject.doFilter(mockRequest, mockResponse, new FilterChain() {
+            public void doFilter(ServletRequest request, ServletResponse response) {
+                assertThat(ServletRequestContextManager.currentServletRequest(), is(sameInstance(request)));
+            }
+        });
+
+        verify(mockRequest).isAsyncStarted();
+    }
+
+    @Test
+    public void testAsyncFiltering() throws IOException, ServletException {
+        AsyncContext mockAsyncContext = mock(AsyncContext.class);
+        when(mockRequest.isAsyncStarted()).thenReturn(true);
+        when(mockRequest.getAsyncContext()).thenReturn(mockAsyncContext);
+
+        subject.doFilter(mockRequest, mockResponse, new FilterChain() {
+            public void doFilter(ServletRequest request, ServletResponse response) {
+                assertThat(ServletRequestContextManager.currentServletRequest(), is(sameInstance(request)));
+            }
+        });
+
+        verify(mockRequest).isAsyncStarted();
+        verify(mockRequest).getAsyncContext();
+        verify(mockAsyncContext).addListener(any(ServletRequestContextAsyncListener.class));
+        verifyNoMoreInteractions(mockAsyncContext);
+    }
+
+    @Test
+    public void testAsyncFiltering_exceptionInAddListener() throws IOException, ServletException {
+        AsyncContext mockAsyncContext = mock(AsyncContext.class);
+        when(mockRequest.isAsyncStarted()).thenReturn(true);
+        when(mockRequest.getAsyncContext()).thenReturn(mockAsyncContext);
+        doThrow(IllegalStateException.class).when(mockAsyncContext).addListener(any(ServletRequestContextAsyncListener.class));
+
+        subject.doFilter(mockRequest, mockResponse, new FilterChain() {
+            public void doFilter(ServletRequest request, ServletResponse response) {
+                assertThat(ServletRequestContextManager.currentServletRequest(), is(sameInstance(request)));
+            }
+        });
+
+        verify(mockRequest).isAsyncStarted();
+        verify(mockRequest).getAsyncContext();
+        verify(mockAsyncContext).addListener(any(ServletRequestContextAsyncListener.class));
+        verifyNoMoreInteractions(mockAsyncContext);
+    }
+}

--- a/servletrequest-propagation/src/test/java/nl/talsmasoftware/context/servletrequest/ServletRequestContextManagerTest.java
+++ b/servletrequest-propagation/src/test/java/nl/talsmasoftware/context/servletrequest/ServletRequestContextManagerTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2016-2018 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.context.servletrequest;
+
+import nl.talsmasoftware.context.Context;
+import nl.talsmasoftware.context.ContextManagers;
+import nl.talsmasoftware.context.executors.ContextAwareExecutorService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.ServletRequest;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.mock;
+
+public class ServletRequestContextManagerTest {
+
+    private ExecutorService threadpool;
+
+    @Before
+    public void init() {
+        ServletRequestContextManager.clear();
+        threadpool = new ContextAwareExecutorService(Executors.newCachedThreadPool());
+    }
+
+    @After
+    public void cleanup() {
+        threadpool.shutdown();
+        ServletRequestContextManager.clear();
+    }
+
+    @Test
+    public void testContextManagerToStringValue() {
+        assertThat(new ServletRequestContextManager(), hasToString(ServletRequestContextManager.class.getSimpleName()));
+    }
+
+    @Test
+    public void testGetActiveContext() {
+        assertThat(new ServletRequestContextManager().getActiveContext(), is(nullValue()));
+
+        final ServletRequest request = mock(ServletRequest.class);
+        Context<ServletRequest> ctx = new ServletRequestContextManager().initializeNewContext(request);
+
+        assertThat(new ServletRequestContextManager().getActiveContext().getValue(), is(sameInstance(request)));
+        ctx.close();
+        assertThat(new ServletRequestContextManager().getActiveContext(), is(nullValue()));
+    }
+
+    @Test
+    public void testCurrentServletRequest() {
+        assertThat(ServletRequestContextManager.currentServletRequest(), is(nullValue()));
+
+        final ServletRequest request = mock(ServletRequest.class);
+        Context<ServletRequest> ctx = new ServletRequestContextManager().initializeNewContext(request);
+
+        assertThat(ServletRequestContextManager.currentServletRequest(), is(sameInstance(request)));
+        ctx.close();
+        assertThat(ServletRequestContextManager.currentServletRequest(), is(nullValue()));
+    }
+
+    @Test
+    public void testClearableImplementation() {
+        final ServletRequest request = mock(ServletRequest.class);
+        Context<ServletRequest> ctx = new ServletRequestContextManager().initializeNewContext(request);
+        assertThat(ctx.getValue(), is(sameInstance(request)));
+        assertThat(new ServletRequestContextManager().getActiveContext().getValue(), is(sameInstance(request)));
+
+        ContextManagers.clearActiveContexts();
+        assertThat(ctx.getValue(), is(nullValue())); // must have been closed
+        assertThat(new ServletRequestContextManager().getActiveContext(), is(nullValue()));
+    }
+
+    @Test
+    public void testPropagationInOtherThreads() throws ExecutionException, InterruptedException {
+        ServletRequestContextManager manager = new ServletRequestContextManager();
+        ServletRequest request1 = mock(ServletRequest.class);
+        ServletRequest request2 = mock(ServletRequest.class);
+
+        Context<ServletRequest> ctx1 = manager.initializeNewContext(request1);
+        try {
+            assertThat("Current context", manager.getActiveContext(), is(notNullValue()));
+            assertThat("Current context value", manager.getActiveContext().getValue(), is(request1));
+
+            Context<ServletRequest> ctx2 = manager.initializeNewContext(request2);
+            final CountDownLatch blocker = new CountDownLatch(1);
+            Future<ServletRequest> slowCall;
+            try {
+
+                slowCall = threadpool.submit(new Callable<ServletRequest>() {
+                    public ServletRequest call() throws InterruptedException {
+                        blocker.await(5, TimeUnit.SECONDS);
+                        return ServletRequestContextManager.currentServletRequest();
+                    }
+                });
+
+            } finally {
+                ctx2.close();
+            }
+            assertThat("Closed context in parent", ServletRequestContextManager.currentServletRequest(), is(nullValue()));
+            assertThat("Slow thread already done", slowCall.isDone(), is(false));
+            blocker.countDown();
+            assertThat("Context in slow thread", slowCall.get(), is(request2));
+
+        } finally {
+            ctx1.close();
+        }
+        assertThat("Current closed context", manager.getActiveContext(), is(nullValue()));
+    }
+
+}

--- a/spring-security-context/src/main/java/nl/talsmasoftware/context/springsecurity/SpringSecurityContextManager.java
+++ b/spring-security-context/src/main/java/nl/talsmasoftware/context/springsecurity/SpringSecurityContextManager.java
@@ -16,7 +16,7 @@
 package nl.talsmasoftware.context.springsecurity;
 
 import nl.talsmasoftware.context.Context;
-import nl.talsmasoftware.context.ContextManager;
+import nl.talsmasoftware.context.clearable.ClearableContextManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -32,7 +32,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * @author Sjoerd Talsma
  */
-public class SpringSecurityContextManager implements ContextManager<Authentication> {
+public class SpringSecurityContextManager implements ClearableContextManager<Authentication> {
 
     /**
      * Creates a new Spring {@linkplain SecurityContext} and sets the {@linkplain Authentication value} in it.
@@ -59,8 +59,16 @@ public class SpringSecurityContextManager implements ContextManager<Authenticati
         return new AuthenticationContext(SecurityContextHolder.getContext(), null, true);
     }
 
+    /**
+     * Clears the Spring {@linkplain SecurityContext} by calling {@linkplain SecurityContextHolder#clearContext()}.
+     */
+    public void clear() {
+        SecurityContextHolder.clearContext();
+    }
+
     private static final class AuthenticationContext implements Context<Authentication> {
-        private final SecurityContext current, previous;
+        private volatile SecurityContext current;
+        private final SecurityContext previous;
         private final AtomicBoolean closed;
 
         private AuthenticationContext(SecurityContext current, SecurityContext previous, boolean alreadyClosed) {

--- a/spring-security-context/src/test/java/nl/talsmasoftware/context/springsecurity/SpringSecurityContextManagerTest.java
+++ b/spring-security-context/src/test/java/nl/talsmasoftware/context/springsecurity/SpringSecurityContextManagerTest.java
@@ -33,7 +33,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  * Unit test for the {@link SpringSecurityContextManager}.
@@ -57,7 +60,7 @@ public class SpringSecurityContextManagerTest {
 
     @Before
     @After
-    public void clearMDC() {
+    public void clearSecurityContext() {
         SecurityContextHolder.clearContext();
     }
 
@@ -111,7 +114,20 @@ public class SpringSecurityContextManagerTest {
 
     @Test
     public void testClosingCurrentAuthenticationContext() {
+        setAuthentication("Vincent Vega");
+        assertThat(new SpringSecurityContextManager().getActiveContext().getValue().getName(), is("Vincent Vega"));
 
+        new SpringSecurityContextManager().getActiveContext().close(); // Not ours to manage!
+        assertThat(new SpringSecurityContextManager().getActiveContext().getValue().getName(), is("Vincent Vega"));
+    }
+
+    @Test
+    public void testClearableImplementation() {
+        setAuthentication("Vincent Vega");
+        assertThat(new SpringSecurityContextManager().getActiveContext().getValue().getName(), is("Vincent Vega"));
+
+        ContextManagers.clearActiveContexts();
+        assertThat(new SpringSecurityContextManager().getActiveContext().getValue(), is(nullValue()));
     }
 
 }


### PR DESCRIPTION
This is intended to fix #74 without breaking compatibility with existing `ContextManager` implementations.

The new `ContextManager.clear()` method is isolated into a new `Clearable` interface so the contract for current `ContextManager` implementations isn't broken.

A `ClearableContextManager` interface is introduced for convenience.