### PR TITLE
Re-introduce caching but make it configurable

### DIFF
--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/ContextManagers.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/ContextManagers.java
@@ -208,12 +208,6 @@ public final class ContextManagers {
 
                 if (!remainingContextManagers.isEmpty()) { // Should not happen, print warnings!
                     CONTEXT_MANAGERS.clearCache();
-                    for (ContextManager contextManager : CONTEXT_MANAGERS) {
-                        String contextManagerName = contextManager.getClass().getName();
-                        if (remainingContextManagers.remove(contextManagerName)) {
-                            reactivatedContexts.add(reactivate(contextManager, snapshot.get(contextManagerName)));
-                        }
-                    }
                     for (String contextManagerName : remainingContextManagers) {
                         LOGGER.log(Level.WARNING, "Context manager \"{0}\" not found in service loader! " +
                                 "Cannot reactivate: {1}", new Object[]{contextManagerName, snapshot.get(contextManagerName)});

--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/PriorityServiceLoader.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/PriorityServiceLoader.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.logging.Level;
@@ -39,6 +40,8 @@ import static java.util.Collections.unmodifiableList;
 final class PriorityServiceLoader<SVC> implements Iterable<SVC> {
     private static final Logger LOGGER = Logger.getLogger(PriorityServiceLoader.class.getName());
     private static final String SYSTEMPROPERTY_CACHING = "talsmasoftware.context.caching";
+    private static final String ENVIRONMENT_CACHING_VALUE = System.getenv(
+            SYSTEMPROPERTY_CACHING.replace('.', '_').toUpperCase(Locale.ENGLISH));
 
     private final Class<SVC> serviceType;
     private final Map<ClassLoader, List<SVC>> cache = new WeakHashMap<ClassLoader, List<SVC>>();
@@ -60,8 +63,7 @@ final class PriorityServiceLoader<SVC> implements Iterable<SVC> {
     }
 
     private static boolean isCachingDisabled() {
-        final String cachingProperty = System.getProperty(SYSTEMPROPERTY_CACHING,
-                System.getenv(SYSTEMPROPERTY_CACHING.replace('.', '_').toUpperCase()));
+        final String cachingProperty = System.getProperty(SYSTEMPROPERTY_CACHING, ENVIRONMENT_CACHING_VALUE);
         return "0".equals(cachingProperty) || "false".equalsIgnoreCase(cachingProperty);
     }
 

--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/PriorityServiceLoader.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/PriorityServiceLoader.java
@@ -54,22 +54,22 @@ final class PriorityServiceLoader<SVC> implements Iterable<SVC> {
 
     @SuppressWarnings("unchecked")
     public Iterator<SVC> iterator() {
-        final ClassLoader cl = Thread.currentThread().getContextClassLoader();
-        List<SVC> services = cache.get(cl);
+        final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        List<SVC> services = cache.get(contextClassLoader);
         if (services == null) {
             services = new ArrayList<SVC>();
-            for (Iterator<SVC> iterator = loadServices(serviceType, cl); iterator.hasNext(); ) {
+            for (Iterator<SVC> iterator = loadServices(serviceType, contextClassLoader); iterator.hasNext(); ) {
                 SVC service = iterator.next();
                 if (service != null) services.add(service);
             }
             services = sortAndMakeUnmodifiable(services);
-            if (!cachingDisabled) cache.put(cl, services);
+            if (!cachingDisabled) cache.put(contextClassLoader, services);
         }
         return services.iterator();
     }
 
     /**
-     * Removes the cache to the next call to {@linkplain #iterator()} will attempt to load the objects again.
+     * Removes the cache so the next call to {@linkplain #iterator()} will attempt to load the objects again.
      */
     void clearCache() {
         cache.clear();

--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/PriorityServiceLoader.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/PriorityServiceLoader.java
@@ -88,7 +88,7 @@ final class PriorityServiceLoader<SVC> implements Iterable<SVC> {
             return java.util.ServiceLoader.load(serviceType, classLoader).iterator();
         } catch (LinkageError le) {
             LOGGER.log(Level.FINEST, "No ServiceLoader available, probably running on Java 1.5.", le);
-            return javax.imageio.spi.ServiceRegistry.lookupProviders(serviceType, classLoader);
+            return javax.imageio.spi.ServiceRegistry.lookupProviders(serviceType);
         } catch (RuntimeException loadingException) {
             LOGGER.log(Level.WARNING, "Unexpected error loading services of " + serviceType, loadingException);
             return Collections.<SVC>emptySet().iterator();

--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/PriorityServiceLoader.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/PriorityServiceLoader.java
@@ -41,15 +41,11 @@ final class PriorityServiceLoader<SVC> implements Iterable<SVC> {
     private static final String SYSTEMPROPERTY_CACHING = "talsmasoftware.context.caching";
 
     private final Class<SVC> serviceType;
-    private final boolean cachingDisabled;
     private final Map<ClassLoader, List<SVC>> cache = new WeakHashMap<ClassLoader, List<SVC>>();
 
     PriorityServiceLoader(Class<SVC> serviceType) {
         if (serviceType == null) throw new NullPointerException("Service type is <null>.");
         this.serviceType = serviceType;
-        final String cachingProperty = System.getProperty(SYSTEMPROPERTY_CACHING,
-                System.getenv(SYSTEMPROPERTY_CACHING.replace('.', '_').toUpperCase()));
-        this.cachingDisabled = "0".equals(cachingProperty) || "false".equalsIgnoreCase(cachingProperty);
     }
 
     @SuppressWarnings("unchecked")
@@ -63,9 +59,15 @@ final class PriorityServiceLoader<SVC> implements Iterable<SVC> {
                 if (service != null) services.add(service);
             }
             services = sortAndMakeUnmodifiable(services);
-            if (!cachingDisabled) cache.put(contextClassLoader, services);
+            if (!isCachingDisabled()) cache.put(contextClassLoader, services);
         }
         return services.iterator();
+    }
+
+    private static boolean isCachingDisabled() {
+        final String cachingProperty = System.getProperty(SYSTEMPROPERTY_CACHING,
+                System.getenv(SYSTEMPROPERTY_CACHING.replace('.', '_').toUpperCase()));
+        return "0".equals(cachingProperty) || "false".equalsIgnoreCase(cachingProperty);
     }
 
     /**

--- a/docs/README.md
+++ b/docs/README.md
@@ -75,6 +75,21 @@ public class DummyContextManager implements ContextManager<String> {
 }
 ```
 
+## Caching
+
+By default the `ContextManagers` class caches the found context manager instances per
+_context classloader_. Since the cache is per classloader, this should work satisfactory
+for applications with simple classloader hierarchies (e.g. _spring boot_, _dropwizard_ etc) 
+and complex hierarchies (JEE and the like).
+
+### Disable caching
+
+If however, you wish to disable caching of the context manager instances, you can:
+- Set the java system property `talsmasoftware.context.caching`, or
+- The environment variable `TALSMASOFTWARE_CONTEXT_CACHNG`
+
+to the values `false` or `0`.
+
 ## Performance metrics
 
 No library is 'free' with regards to performance.

--- a/docs/README.md
+++ b/docs/README.md
@@ -84,9 +84,9 @@ and complex hierarchies (JEE and the like).
 
 ### Disable caching
 
-If however, you wish to disable caching of the context manager instances, you can:
-- Set the java system property `talsmasoftware.context.caching`, or
-- The environment variable `TALSMASOFTWARE_CONTEXT_CACHNG`
+If however, you wish to disable caching of the context manager instances, you can set either:
+- the java system property `talsmasoftware.context.caching`, or
+- the environment variable `TALSMASOFTWARE_CONTEXT_CACHNG`
 
 to the values `false` or `0`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -77,7 +77,7 @@ public class DummyContextManager implements ContextManager<String> {
 
 ## Caching
 
-By default the `ContextManagers` class caches the found context manager instances per
+By default the `ContextManagers` class caches the context manager instances it finds per
 _context classloader_. Since the cache is per classloader, this should work satisfactory
 for applications with simple classloader hierarchies (e.g. _spring boot_, _dropwizard_ etc) 
 and complex hierarchies (JEE and the like).


### PR DESCRIPTION
1. Caching can be explicitly disabled by:
   1. Running with system property `talsmasoftware.context.caching` set
      to `0` or `false`
   2. Running with environment variable `TALSMASOFTWARE_CONTEXT_CACHING`
      set to `0` or `false`
2. Caching can be explicitly enabled by:
   1. Running with system property `talsmasoftware.context.caching` set
      to `1` or `true`
   2. Running with environment variable `TALSMASOFTWARE_CONTEXT_CACHING`
      set to `1` or `true`
3. If no caching is configured, by default, the found `ContextManager`
   instances will be cached if:
   1. At least one is found
   2. All fount context managers were loaded by the same classloader the
      `ContextManagers` utility was also loaded from from.
      (in an attempt to avoid caching where it is inappropriate)

Hopefully this fixes #78 