### PR TITLE
Introduce ContextObserver API

### DIFF
--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/Context.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/Context.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Talsma ICT
+ * Copyright 2016-2019 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,9 @@ import java.io.Closeable;
 
 /**
  * A context can be anything that needs to be maintained on the 'current thread' level.
+ * <p>
+ * It is the responsibility of the one activating a new context to
+ * also {@linkplain #close() close} it again <em>from the same thread</em>.
  * <p>
  * Implementations are typically maintained within a static {@link ThreadLocal} variable.<br>
  * A context has a very simple life-cycle: they can be created and {@link #close() closed}.
@@ -48,8 +51,9 @@ public interface Context<T> extends Closeable {
     T getValue();
 
     /**
-     * Closes this context and restores any context changes made by this object to the way things were before it
-     * got created.
+     * Closes this context.
+     * <p>
+     * It is the responsibility of the one activating a new context to also close it again <em>from the same thread</em>.
      * <p>
      * It must be possible to call this method multiple times.
      * It is the responsibility of the implementor of this context to make sure that closing an already-closed context
@@ -57,6 +61,7 @@ public interface Context<T> extends Closeable {
      * A simple way to achieve this is by using an {@link java.util.concurrent.atomic.AtomicBoolean} to make sure the
      * 'closing' transition is executed only once.
      * <p>
+     * Implementors should attempt to restore previous contextual state upon close.
      *
      * @throws RuntimeException if an error occurs while restoring the context.
      */

--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/ContextManager.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/ContextManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Talsma ICT
+ * Copyright 2016-2019 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,20 @@ package nl.talsmasoftware.context;
 /**
  * The contract for a ContextManager Service.
  * <p>
- * Concrete implementations can be registered by providing an implementation class with a default constructor,
- * along with a class declaration in a service file called:<br>
- * <code>"/META-INF/services/nl.talsmasoftware.context.ContextManager"</code>
- * <p>
+ * Implementations can be registered by providing a fully qualified class name in a service file called:<br>
+ * <code>"/META-INF/services/nl.talsmasoftware.context.ContextManager"</code><br>
  * That will take care of any active context being captured in {@link ContextSnapshot} instances
- * managed by the {@link ContextManagers} utility class.
+ * managed by the {@link ContextManagers} utility class.<br>
+ * <b>Note:</b> <em>Make sure your implementation has a default (no-argument) constructor.</em>
+ * <p>
+ * A context manager is required to notify
+ * registered {@linkplain nl.talsmasoftware.context.observer.ContextObserver ContextObserver}
+ * of context updates.
+ * Using the {@linkplain nl.talsmasoftware.context.threadlocal.AbstractThreadLocalContext AbstractThreadLocalContext}
+ * already fulfills this requirement.
+ * Other implementations can use the utility methods defined in
+ * {@linkplain nl.talsmasoftware.context.observer.ContextObservers} to locate the appropriate context observers
+ * to be notified.
  *
  * @author Sjoerd Talsma
  */

--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/PriorityServiceLoader.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/PriorityServiceLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Talsma ICT
+ * Copyright 2016-2019 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import static java.util.Collections.unmodifiableList;
  * @param <SVC> The type of service to load.
  * @author Sjoerd Talsma
  */
-final class PriorityServiceLoader<SVC> implements Iterable<SVC> {
+public final class PriorityServiceLoader<SVC> implements Iterable<SVC> {
     private static final Logger LOGGER = Logger.getLogger(PriorityServiceLoader.class.getName());
     private static final String SYSTEMPROPERTY_CACHING = "talsmasoftware.context.caching";
     private static final String ENVIRONMENT_CACHING_VALUE = System.getenv(
@@ -46,7 +46,7 @@ final class PriorityServiceLoader<SVC> implements Iterable<SVC> {
     private final Class<SVC> serviceType;
     private final Map<ClassLoader, List<SVC>> cache = new WeakHashMap<ClassLoader, List<SVC>>();
 
-    PriorityServiceLoader(Class<SVC> serviceType) {
+    public PriorityServiceLoader(Class<SVC> serviceType) {
         if (serviceType == null) throw new NullPointerException("Service type is <null>.");
         this.serviceType = serviceType;
     }
@@ -62,16 +62,16 @@ final class PriorityServiceLoader<SVC> implements Iterable<SVC> {
         return services.iterator();
     }
 
-    private static boolean isCachingDisabled() {
-        final String cachingProperty = System.getProperty(SYSTEMPROPERTY_CACHING, ENVIRONMENT_CACHING_VALUE);
-        return "0".equals(cachingProperty) || "false".equalsIgnoreCase(cachingProperty);
-    }
-
     /**
      * Removes the cache so the next call to {@linkplain #iterator()} will attempt to load the objects again.
      */
-    void clearCache() {
+    public void clearCache() {
         cache.clear();
+    }
+
+    private static boolean isCachingDisabled() {
+        final String cachingProperty = System.getProperty(SYSTEMPROPERTY_CACHING, ENVIRONMENT_CACHING_VALUE);
+        return "0".equals(cachingProperty) || "false".equalsIgnoreCase(cachingProperty);
     }
 
     private List<SVC> findServices(ClassLoader classLoader) {

--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/observer/ContextObserver.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/observer/ContextObserver.java
@@ -50,7 +50,7 @@ public interface ContextObserver<T> {
      *
      * @return The observed context manager class or {@code null} to disable this observer.
      */
-    Class<? extends ContextManager<T>> getObservedContext();
+    Class<? extends ContextManager<T>> getObservedContextManager();
 
     /**
      * Indicates that a context <em>was just activated</em>.

--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/observer/ContextObserver.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/observer/ContextObserver.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016-2019 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.context.observer;
+
+import nl.talsmasoftware.context.ContextManager;
+
+/**
+ * Observe context updates for a particular class of {@linkplain ContextManager}.
+ * <p>
+ * Create your context observer by implementing this interface
+ * and registering your class to the {@code ServiceLoader}
+ * SPI by adding the fully qualified class name to the resource
+ * {@code /META-INF/services/nl.talsmasoftware.context.observer.ContextObserver}.
+ * <p>
+ * It is the responsibility of the context implementor to update observers of
+ * context updates. SPI lookup of appropriate observers is facilitated
+ * by the {@linkplain ContextObservers#onActivate(Class, Object, Object)}
+ * and {@linkplain ContextObservers#onDeactivate(Class, Object, Object)}
+ * utility methods.<br>
+ * All subclasses of {@code AbstractThreadLocalContext} are already observable.
+ *
+ * @author Sjoerd Talsma
+ */
+public interface ContextObserver<T> {
+
+    /**
+     * The observed context manager(s).
+     * <p>
+     * Context observers can indicate which type of context manager must be observed using this method.
+     * For instance, returning {@code LocaleContextManager.class} here, updates for the {@code LocaleContext} will
+     * be offered to this observer.
+     * <p>
+     * To observe <em>all</em> context updates, return the {@linkplain ContextManager} interface class itself,
+     * since all context managers must implement it.
+     * <p>
+     * Return {@code null} to disable the observer.
+     *
+     * @return The observed context manager class or {@code null} to disable this observer.
+     */
+    Class<? extends ContextManager<T>> getObservedContext();
+
+    /**
+     * Indicates that a context <em>was just activated</em>.
+     *
+     * @param activatedContextValue The now active context value.
+     * @param previousContextValue  The previous context value or {@code null} if unknown or unsupported.
+     */
+    void onActivate(T activatedContextValue, T previousContextValue);
+
+    /**
+     * Indicates that a context <em>was just deactivated</em>.
+     *
+     * @param deactivatedContextValue The deactivated context value.
+     * @param restoredContextValue    The now active restored context value or {@code null} if unknown or unsupported.
+     */
+    void onDeactivate(T deactivatedContextValue, T restoredContextValue);
+
+}

--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/observer/ContextObservers.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/observer/ContextObservers.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016-2019 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.context.observer;
+
+import nl.talsmasoftware.context.ContextManager;
+import nl.talsmasoftware.context.PriorityServiceLoader;
+
+public final class ContextObservers {
+
+    /**
+     * The service loader that loads (and possibly caches) {@linkplain ContextManager} instances in prioritized order.
+     */
+    private static final PriorityServiceLoader<ContextObserver> CONTEXT_OBSERVERS =
+            new PriorityServiceLoader<ContextObserver>(ContextObserver.class);
+
+    /**
+     * Private constructor to avoid instantiation of this class.
+     */
+    private ContextObservers() {
+        throw new UnsupportedOperationException();
+    }
+
+    public static <T> void onActivate(Class<? extends ContextManager<? super T>> contextManager,
+                                      T activatedContextValue,
+                                      T previousContextValue) {
+        if (contextManager != null) for (ContextObserver observer : CONTEXT_OBSERVERS) {
+            final Class observedContext = observer.getObservedContext();
+            if (observedContext != null && observedContext.isAssignableFrom(contextManager)) {
+                observer.onActivate(activatedContextValue, previousContextValue);
+            }
+        }
+    }
+
+    public static <T> void onDeactivate(Class<? extends ContextManager<? super T>> contextManager,
+                                        T deactivatedContextValue,
+                                        T restoredContextValue) {
+        if (contextManager != null) for (ContextObserver observer : CONTEXT_OBSERVERS) {
+            final Class observedContext = observer.getObservedContext();
+            if (observedContext != null && observedContext.isAssignableFrom(contextManager)) {
+                observer.onDeactivate(deactivatedContextValue, restoredContextValue);
+            }
+        }
+    }
+
+}

--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/observer/ContextObservers.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/observer/ContextObservers.java
@@ -60,16 +60,15 @@ public final class ContextObservers {
                                       T previousContextValue) {
         if (contextManager != null) for (ContextObserver observer : CONTEXT_OBSERVERS) {
             try {
-                final Class observedContext = observer.getObservedContext();
+                final Class observedContext = observer.getObservedContextManager();
                 if (observedContext != null && observedContext.isAssignableFrom(contextManager)) {
                     observer.onActivate(activatedContextValue, previousContextValue);
                 }
             } catch (RuntimeException observationException) {
                 Logger.getLogger(observer.getClass().getName()).log(Level.WARNING,
-                        "Exception notifying observer " + observer
-                                + " for context manager " + contextManager.getSimpleName()
-                                + " of activated context value " + activatedContextValue
-                                + " (previous: " + previousContextValue + "): " + observationException.getMessage(),
+                        "Exception in " + observer.getClass().getSimpleName()
+                                + ".onActivate(" + activatedContextValue + ", " + previousContextValue
+                                + ") for " + contextManager.getSimpleName() + ": " + observationException.getMessage(),
                         observationException);
             }
         }
@@ -90,16 +89,15 @@ public final class ContextObservers {
                                         T restoredContextValue) {
         if (contextManager != null) for (ContextObserver observer : CONTEXT_OBSERVERS) {
             try {
-                final Class observedContext = observer.getObservedContext();
+                final Class observedContext = observer.getObservedContextManager();
                 if (observedContext != null && observedContext.isAssignableFrom(contextManager)) {
                     observer.onDeactivate(deactivatedContextValue, restoredContextValue);
                 }
             } catch (RuntimeException observationException) {
                 Logger.getLogger(observer.getClass().getName()).log(Level.WARNING,
-                        "Exception notifying observer " + observer
-                                + " for context manager " + contextManager.getSimpleName()
-                                + " of deactivated context value " + deactivatedContextValue
-                                + " (restored: " + restoredContextValue + "): " + observationException.getMessage(),
+                        "Exception in " + observer.getClass().getSimpleName()
+                                + ".onDeactivate(" + deactivatedContextValue + ", " + deactivatedContextValue
+                                + ") for " + contextManager.getSimpleName() + ": " + observationException.getMessage(),
                         observationException);
             }
         }

--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/observer/ContextObservers.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/observer/ContextObservers.java
@@ -18,6 +18,18 @@ package nl.talsmasoftware.context.observer;
 import nl.talsmasoftware.context.ContextManager;
 import nl.talsmasoftware.context.PriorityServiceLoader;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Utility class to assist Context implementors.
+ * <p>
+ * It implements the SPI behaviour, locating appropriate {@linkplain ContextObserver}
+ * implementations to be notified of {@linkplain #onActivate(Class, Object, Object) activate}
+ * and {@linkplain #onDeactivate(Class, Object, Object) deactivate} occurrances.
+ *
+ * @author Sjoerd Talsma
+ */
 public final class ContextObservers {
 
     /**
@@ -33,24 +45,62 @@ public final class ContextObservers {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Notifies all {@linkplain ContextObserver context observers} for the specified {@code contextManager}
+     * about the activated context value.
+     *
+     * @param contextManager        The context manager type that activated the context (required to observe).
+     * @param activatedContextValue The activated context value or {@code null} if no value was activated.
+     * @param previousContextValue  The previous context value or {@code null} if unknown or unsupported.
+     * @param <T>                   The type managed by the context manager.
+     */
+    @SuppressWarnings("unchecked") // If the observer tells us it can observe the values, we trust it.
     public static <T> void onActivate(Class<? extends ContextManager<? super T>> contextManager,
                                       T activatedContextValue,
                                       T previousContextValue) {
         if (contextManager != null) for (ContextObserver observer : CONTEXT_OBSERVERS) {
-            final Class observedContext = observer.getObservedContext();
-            if (observedContext != null && observedContext.isAssignableFrom(contextManager)) {
-                observer.onActivate(activatedContextValue, previousContextValue);
+            try {
+                final Class observedContext = observer.getObservedContext();
+                if (observedContext != null && observedContext.isAssignableFrom(contextManager)) {
+                    observer.onActivate(activatedContextValue, previousContextValue);
+                }
+            } catch (RuntimeException observationException) {
+                Logger.getLogger(observer.getClass().getName()).log(Level.WARNING,
+                        "Exception notifying observer " + observer
+                                + " for context manager " + contextManager.getSimpleName()
+                                + " of activated context value " + activatedContextValue
+                                + " (previous: " + previousContextValue + "): " + observationException.getMessage(),
+                        observationException);
             }
         }
     }
 
+    /**
+     * Notifies all {@linkplain ContextObserver context observers} for the specified {@code contextManager}
+     * about the deactivated context value.
+     *
+     * @param contextManager          The context manager type that deactivated the context (required to observe).
+     * @param deactivatedContextValue The deactivated context value
+     * @param restoredContextValue    The restored context value or {@code null} if unknown or unsupported.
+     * @param <T>                     The type managed by the context manager.
+     */
+    @SuppressWarnings("unchecked") // If the observer tells us it can observe the values, we trust it.
     public static <T> void onDeactivate(Class<? extends ContextManager<? super T>> contextManager,
                                         T deactivatedContextValue,
                                         T restoredContextValue) {
         if (contextManager != null) for (ContextObserver observer : CONTEXT_OBSERVERS) {
-            final Class observedContext = observer.getObservedContext();
-            if (observedContext != null && observedContext.isAssignableFrom(contextManager)) {
-                observer.onDeactivate(deactivatedContextValue, restoredContextValue);
+            try {
+                final Class observedContext = observer.getObservedContext();
+                if (observedContext != null && observedContext.isAssignableFrom(contextManager)) {
+                    observer.onDeactivate(deactivatedContextValue, restoredContextValue);
+                }
+            } catch (RuntimeException observationException) {
+                Logger.getLogger(observer.getClass().getName()).log(Level.WARNING,
+                        "Exception notifying observer " + observer
+                                + " for context manager " + contextManager.getSimpleName()
+                                + " of deactivated context value " + deactivatedContextValue
+                                + " (restored: " + restoredContextValue + "): " + observationException.getMessage(),
+                        observationException);
             }
         }
     }

--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/threadlocal/AbstractThreadLocalContext.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/threadlocal/AbstractThreadLocalContext.java
@@ -34,6 +34,7 @@ import java.util.logging.Logger;
  * @author Sjoerd Talsma
  */
 public abstract class AbstractThreadLocalContext<T> implements Context<T> {
+    private static final AtomicBoolean DEPRECATED_CONSTRUCTOR_WARNING = new AtomicBoolean(true);
     /**
      * The constant of ThreadLocal context instances per subclass name so different types don't get mixed.
      */
@@ -60,6 +61,24 @@ public abstract class AbstractThreadLocalContext<T> implements Context<T> {
      * on the desired features of the particular implementation.
      */
     protected final T value;
+
+    /**
+     * Instantiates a new context with the specified value.
+     * The new context will be made the active context for the current thread.
+     *
+     * @param newValue The new value to become active in this new context
+     *                 (or <code>null</code> to register a new context with 'no value').
+     * @deprecated Using this constructor makes it impossible to register a {@code ContextObserver}!
+     */
+    @Deprecated
+    protected AbstractThreadLocalContext(T newValue) {
+        this(null, newValue);
+        logger.log(DEPRECATED_CONSTRUCTOR_WARNING.compareAndSet(true, false) ? Level.WARNING : Level.FINE,
+                "Initialized new {0} without context manager type. " +
+                        "This makes it impossible to register ContextObservers for it. " +
+                        "Please fix this context by specifying a ContextManager type " +
+                        "using the correct AbstractThreadLocalContext constructor.", this);
+    }
 
     /**
      * Instantiates a new context with the specified value.

--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/threadlocal/AbstractThreadLocalContext.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/threadlocal/AbstractThreadLocalContext.java
@@ -76,8 +76,9 @@ public abstract class AbstractThreadLocalContext<T> implements Context<T> {
         logger.log(DEPRECATED_CONSTRUCTOR_WARNING.compareAndSet(true, false) ? Level.WARNING : Level.FINE,
                 "Initialized new {0} without context manager type. " +
                         "This makes it impossible to register ContextObservers for it. " +
-                        "Please fix this context by specifying a ContextManager type " +
-                        "using the correct AbstractThreadLocalContext constructor.", this);
+                        "Please fix {1} by specifying a ContextManager type " +
+                        "in the AbstractThreadLocalContext constructor.",
+                new Object[]{this, getClass().getSimpleName()});
     }
 
     /**

--- a/context-propagation-java5/src/test/java/nl/talsmasoftware/context/DummyContext.java
+++ b/context-propagation-java5/src/test/java/nl/talsmasoftware/context/DummyContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Talsma ICT
+ * Copyright 2016-2019 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ final class DummyContext extends AbstractThreadLocalContext<String> {
             AbstractThreadLocalContext.threadLocalInstanceOf(DummyContext.class);
 
     DummyContext(String newValue) {
-        super(newValue);
+        super(DummyContextManager.class, newValue);
     }
 
     // Public for testing!

--- a/context-propagation-java5/src/test/java/nl/talsmasoftware/context/ThrowingContextManager.java
+++ b/context-propagation-java5/src/test/java/nl/talsmasoftware/context/ThrowingContextManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Talsma ICT
+ * Copyright 2016-2019 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ public class ThrowingContextManager implements ContextManager<String> {
 
     private final static class Ctx extends AbstractThreadLocalContext<String> {
         private Ctx(String newValue) {
-            super(newValue);
+            super(ThrowingContextManager.class, newValue);
         }
 
         private static Ctx current() {

--- a/context-propagation-java5/src/test/java/nl/talsmasoftware/context/observer/ContextObserversTest.java
+++ b/context-propagation-java5/src/test/java/nl/talsmasoftware/context/observer/ContextObserversTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016-2019 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.context.observer;
+
+import org.junit.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+
+public class ContextObserversTest {
+
+    @Test
+    public void testUnsupportedConstructor() {
+        Constructor<?>[] constructors = ContextObservers.class.getDeclaredConstructors();
+        assertThat("Number of constructors", constructors.length, is(1));
+        assertThat("Constructor parameters", constructors[0].getParameterTypes().length, is(0));
+        assertThat("Constructor accessibility", constructors[0].isAccessible(), is(false));
+        try {
+            constructors[0].setAccessible(true);
+            constructors[0].newInstance();
+            fail("InvocationTargetException expected.");
+        } catch (IllegalAccessException e) {
+            fail("InvocationTargetException expected.");
+        } catch (InstantiationException e) {
+            fail("InvocationTargetException expected.");
+        } catch (InvocationTargetException expected) {
+            assertThat(expected.getCause(), is(instanceOf(UnsupportedOperationException.class)));
+        }
+    }
+
+
+}

--- a/context-propagation-java5/src/test/java/nl/talsmasoftware/context/observer/ContextObserversTest.java
+++ b/context-propagation-java5/src/test/java/nl/talsmasoftware/context/observer/ContextObserversTest.java
@@ -29,12 +29,16 @@ import java.lang.reflect.InvocationTargetException;
 
 import static nl.talsmasoftware.context.observer.Observed.Action.ACTIVATE;
 import static nl.talsmasoftware.context.observer.Observed.Action.DEACTIVATE;
+import static nl.talsmasoftware.context.observer.Observed.activated;
+import static nl.talsmasoftware.context.observer.Observed.deactivated;
 import static nl.talsmasoftware.context.observer.SimpleContextObserver.observed;
 import static nl.talsmasoftware.context.observer.SimpleContextObserver.observedContextManager;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.fail;
 
 public class ContextObserversTest {
@@ -122,6 +126,24 @@ public class ContextObserversTest {
         assertThat(observed, contains(
                 new Observed(ACTIVATE, "Activated context", null),
                 new Observed(DEACTIVATE, "Activated context", null)));
+    }
+
+    @Test
+    public void testUnobservableDeprecatedLegacyAbstractThreadLocalContext() {
+        observedContextManager = DeprecatedContextManager.class;
+        final ContextManager<String> manager = new DeprecatedContextManager();
+        final Context<String> ctx = manager.initializeNewContext("Activated context");
+        Context<String> ctx2 = null;
+        try {
+            assertThat(manager.getActiveContext().getValue(), is("Activated context"));
+            assertThat(observed, not(hasItem(activated(is("Activated context")))));
+            ctx2 = manager.initializeNewContext("Nested active context");
+
+        } finally {
+            if (ctx2 != null) ctx2.close();
+            ctx.close();
+        }
+        assertThat(observed, not(hasItem(deactivated(is("Activated context")))));
     }
 
 }

--- a/context-propagation-java5/src/test/java/nl/talsmasoftware/context/observer/DeprecatedContextManager.java
+++ b/context-propagation-java5/src/test/java/nl/talsmasoftware/context/observer/DeprecatedContextManager.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016-2019 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.context.observer;
+
+import nl.talsmasoftware.context.Context;
+import nl.talsmasoftware.context.ContextManager;
+import nl.talsmasoftware.context.threadlocal.AbstractThreadLocalContext;
+
+@SuppressWarnings("deprecation") // The whole idea of this class is to test deprecated behaviour
+public class DeprecatedContextManager implements ContextManager<String> {
+
+    public Context<String> initializeNewContext(String value) {
+        return new DeprecatedContext(value);
+    }
+
+    public Context<String> getActiveContext() {
+        return DeprecatedContext.current();
+    }
+
+    private static final class DeprecatedContext extends AbstractThreadLocalContext<String> {
+        private DeprecatedContext(String value) {
+            super(value);
+        }
+
+        private static DeprecatedContext current() {
+            return current(DeprecatedContext.class);
+        }
+    }
+
+}

--- a/context-propagation-java5/src/test/java/nl/talsmasoftware/context/observer/Observed.java
+++ b/context-propagation-java5/src/test/java/nl/talsmasoftware/context/observer/Observed.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2016-2019 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.context.observer;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+import java.util.Arrays;
+
+final class Observed {
+
+    enum Action {
+        ACTIVATE, DEACTIVATE
+    }
+
+    final Action action;
+    final Object value;
+
+    Observed(Action action, Object value, Object previous) {
+        this.action = action;
+        this.value = value;
+    }
+
+    public static Matcher<Observed> activated(final Matcher<?> delegate) {
+        return new BaseMatcher<Observed>() {
+            public boolean matches(Object actual) {
+                return actual instanceof Observed
+                        && Action.ACTIVATE.equals(((Observed) actual).action)
+                        && delegate.matches(((Observed) actual).value);
+            }
+
+            public void describeTo(Description description) {
+                delegate.describeTo(description.appendText("<Activated> "));
+            }
+        };
+    }
+
+    public static Matcher<Observed> deactivated(final Matcher<?> delegate) {
+        return new BaseMatcher<Observed>() {
+            public boolean matches(Object actual) {
+                return actual instanceof Observed
+                        && Action.DEACTIVATE.equals(((Observed) actual).action)
+                        && delegate.matches(((Observed) actual).value);
+            }
+
+            public void describeTo(Description description) {
+                delegate.describeTo(description.appendText("<Deactivated> "));
+            }
+        };
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(new Object[]{action, value});
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other || (other instanceof Observed
+                && equals(this.action, ((Observed) other).action)
+                && equals(this.value, ((Observed) other).value)
+        );
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "{action=" + action + ", value=" + value + '}';
+    }
+
+    private static boolean equals(Object obj1, Object obj2) {
+        return obj1 == null ? obj2 == null : obj1.equals(obj2);
+    }
+
+}

--- a/context-propagation-java5/src/test/java/nl/talsmasoftware/context/observer/SimpleContextObserver.java
+++ b/context-propagation-java5/src/test/java/nl/talsmasoftware/context/observer/SimpleContextObserver.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016-2019 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.context.observer;
+
+import nl.talsmasoftware.context.ContextManager;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class SimpleContextObserver implements ContextObserver<Object> {
+    static Class<? extends ContextManager> observedContextManager = null;
+
+    static final List<Observed> observed = new CopyOnWriteArrayList<Observed>();
+
+    @SuppressWarnings("unchecked")
+    public Class<? extends ContextManager<Object>> getObservedContextManager() {
+        return (Class) observedContextManager;
+    }
+
+    public void onActivate(Object activatedContextValue, Object previousContextValue) {
+        observed.add(new Observed(Observed.Action.ACTIVATE, activatedContextValue, previousContextValue));
+    }
+
+    public void onDeactivate(Object deactivatedContextValue, Object restoredContextValue) {
+        observed.add(new Observed(Observed.Action.DEACTIVATE, deactivatedContextValue, restoredContextValue));
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+
+}

--- a/context-propagation-java5/src/test/java/nl/talsmasoftware/context/observer/ThrowingContextObserver.java
+++ b/context-propagation-java5/src/test/java/nl/talsmasoftware/context/observer/ThrowingContextObserver.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016-2019 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.context.observer;
+
+import nl.talsmasoftware.context.ContextManager;
+
+import javax.annotation.Priority;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Priority(Integer.MIN_VALUE)
+public class ThrowingContextObserver implements ContextObserver<Object> {
+    static Class<? extends ContextManager<?>> observedContextManager = null;
+
+    static final List<Observed> observed = new CopyOnWriteArrayList<Observed>();
+
+    @SuppressWarnings("unchecked")
+    public Class<? extends ContextManager<Object>> getObservedContextManager() {
+        return (Class) observedContextManager;
+    }
+
+    public void onActivate(Object activatedContextValue, Object previousContextValue) {
+        observed.add(new Observed(Observed.Action.ACTIVATE, activatedContextValue, previousContextValue));
+        throw new UnsupportedOperationException("Method onActivate is not supported!");
+    }
+
+    public void onDeactivate(Object deactivatedContextValue, Object restoredContextValue) {
+        observed.add(new Observed(Observed.Action.DEACTIVATE, deactivatedContextValue, restoredContextValue));
+        throw new UnsupportedOperationException("Method onDeactivate is not supported!");
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+
+}

--- a/context-propagation-java5/src/test/java/nl/talsmasoftware/context/observer/ThrowingContextObserverTest.java
+++ b/context-propagation-java5/src/test/java/nl/talsmasoftware/context/observer/ThrowingContextObserverTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016-2019 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.context.observer;
+
+import nl.talsmasoftware.context.Context;
+import nl.talsmasoftware.context.DummyContextManager;
+import org.junit.Test;
+
+import static nl.talsmasoftware.context.observer.Observed.activated;
+import static nl.talsmasoftware.context.observer.Observed.deactivated;
+import static nl.talsmasoftware.context.observer.ThrowingContextObserver.observed;
+import static nl.talsmasoftware.context.observer.ThrowingContextObserver.observedContextManager;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * Test for context observers that throw exceptions.
+ */
+public class ThrowingContextObserverTest {
+    private static DummyContextManager MGR = new DummyContextManager();
+
+    @Test
+    public void testExceptionDoesNotPreventFunctionality() {
+        observedContextManager = MGR.getClass();
+        observed.clear();
+        try {
+
+            Context<String> ctx = MGR.initializeNewContext("Some value");
+            try {
+
+                assertThat(MGR.getActiveContext().getValue(), is("Some value"));
+                assertThat(observed, hasItem(activated(is("Some value"))));
+                assertThat(observed, not(hasItem(deactivated(is("Some value")))));
+
+            } finally {
+                ctx.close();
+            }
+
+            assertThat(MGR.getActiveContext(), is(nullValue()));
+            assertThat(observed, hasItem(deactivated(is("Some value"))));
+
+        } finally {
+            observedContextManager = null;
+        }
+    }
+
+}

--- a/context-propagation-java5/src/test/resources/META-INF/services/nl.talsmasoftware.context.ContextManager
+++ b/context-propagation-java5/src/test/resources/META-INF/services/nl.talsmasoftware.context.ContextManager
@@ -3,3 +3,4 @@ nl.talsmasoftware.context.ThrowingContextManager
 nl.talsmasoftware.context.clearable.AutoInitializingContextManager
 nl.talsmasoftware.context.clearable.ClearableDummyContextManager
 nl.talsmasoftware.context.clearable.DummyManagerOfClearableContext
+nl.talsmasoftware.context.observer.DeprecatedContextManager

--- a/context-propagation-java5/src/test/resources/META-INF/services/nl.talsmasoftware.context.observer.ContextObserver
+++ b/context-propagation-java5/src/test/resources/META-INF/services/nl.talsmasoftware.context.observer.ContextObserver
@@ -1,0 +1,2 @@
+nl.talsmasoftware.context.observer.ThrowingContextObserver
+nl.talsmasoftware.context.observer.SimpleContextObserver

--- a/context-propagation-java8/src/test/java/nl/talsmasoftware/context/DummyContextManager.java
+++ b/context-propagation-java8/src/test/java/nl/talsmasoftware/context/DummyContextManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Talsma ICT
+ * Copyright 2016-2019 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ public class DummyContextManager implements ContextManager<String> {
 
     private static final class DummyContext extends AbstractThreadLocalContext<String> {
         private DummyContext(String newValue) {
-            super(newValue);
+            super(DummyContextManager.class, newValue);
         }
 
         private static void clear() {

--- a/locale-context/src/main/java/nl/talsmasoftware/context/locale/LocaleContext.java
+++ b/locale-context/src/main/java/nl/talsmasoftware/context/locale/LocaleContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Talsma ICT
+ * Copyright 2016-2019 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ final class LocaleContext extends AbstractThreadLocalContext<Locale> implements 
      *                 (or <code>null</code> to register a new context with 'no value').
      */
     LocaleContext(Locale newValue) {
-        super(newValue);
+        super(LocaleContextManager.class, newValue);
     }
 
     /**

--- a/mdc-propagation/src/main/java/nl/talsmasoftware/context/mdc/MdcManager.java
+++ b/mdc-propagation/src/main/java/nl/talsmasoftware/context/mdc/MdcManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Talsma ICT
+ * Copyright 2016-2019 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package nl.talsmasoftware.context.mdc;
 import nl.talsmasoftware.context.Context;
 import nl.talsmasoftware.context.ContextManager;
 import nl.talsmasoftware.context.clearable.Clearable;
+import nl.talsmasoftware.context.observer.ContextObservers;
 import org.slf4j.MDC;
 
 import java.util.Map;
@@ -87,6 +88,7 @@ public class MdcManager implements ContextManager<Map<String, String>> {
             this.previous = previous;
             this.value = value;
             this.closed = new AtomicBoolean(closed);
+            ContextObservers.onActivate(MdcManager.class, value, previous);
         }
 
         public Map<String, String> getValue() {
@@ -97,6 +99,7 @@ public class MdcManager implements ContextManager<Map<String, String>> {
             if (closed.compareAndSet(false, true)) {
                 if (previous == null) MDC.clear();
                 else MDC.setContextMap(previous);
+                ContextObservers.onDeactivate(MdcManager.class, value, previous);
             }
         }
 

--- a/opentracing-span-propagation/src/main/java/nl/talsmasoftware/context/opentracing/SpanManager.java
+++ b/opentracing-span-propagation/src/main/java/nl/talsmasoftware/context/opentracing/SpanManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Talsma ICT
+ * Copyright 2016-2019 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import io.opentracing.Span;
 import io.opentracing.util.GlobalTracer;
 import nl.talsmasoftware.context.Context;
 import nl.talsmasoftware.context.ContextManager;
+import nl.talsmasoftware.context.observer.ContextObservers;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -88,6 +89,7 @@ public class SpanManager implements ContextManager<Span> {
         private SpanContext(Span span, Scope scope) {
             this.span = span;
             this.scope = scope;
+            ContextObservers.onActivate(SpanManager.class, span, null);
         }
 
         @Override
@@ -97,8 +99,11 @@ public class SpanManager implements ContextManager<Span> {
 
         @Override
         public void close() {
-            if (closed.compareAndSet(false, true) && scope != null) {
-                scope.close();
+            if (closed.compareAndSet(false, true)) {
+                if (scope != null) {
+                    scope.close();
+                }
+                ContextObservers.onDeactivate(SpanManager.class, span, null);
             }
         }
 

--- a/servletrequest-propagation/src/main/java/nl/talsmasoftware/context/servletrequest/ServletRequestContext.java
+++ b/servletrequest-propagation/src/main/java/nl/talsmasoftware/context/servletrequest/ServletRequestContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Talsma ICT
+ * Copyright 2016-2019 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package nl.talsmasoftware.context.servletrequest;
 
 import nl.talsmasoftware.context.Context;
+import nl.talsmasoftware.context.observer.ContextObservers;
 
 import javax.servlet.ServletRequest;
 
@@ -33,6 +34,7 @@ final class ServletRequestContext implements Context<ServletRequest> {
     ServletRequestContext(ServletRequest servletRequest) {
         this.servletRequest = servletRequest;
         CONTEXT.set(this);
+        ContextObservers.onActivate(ServletRequestContextManager.class, servletRequest, null);
     }
 
     static Context<ServletRequest> current() {
@@ -44,8 +46,10 @@ final class ServletRequestContext implements Context<ServletRequest> {
     }
 
     public void close() {
+        final ServletRequest deactivated = servletRequest;
         servletRequest = null;
         CONTEXT.set(null);
+        ContextObservers.onDeactivate(ServletRequestContextManager.class, deactivated, null);
     }
 
     @Override


### PR DESCRIPTION
Allow `ContextObserver` interface to be notified with context updates
for particular (or all) ContextManagers.

This fixes #91

Responsibility for observable contexts lies with the context implementor
but the `AbstractThreadLocalContext` has already been extended with this
functionality.