### PR TITLE
Fix Java 11 and ForkJoinPool.commonPool() class loading issue

### DIFF
--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/ContextManagers.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/ContextManagers.java
@@ -17,7 +17,6 @@ package nl.talsmasoftware.context;
 
 import nl.talsmasoftware.context.clearable.Clearable;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -58,15 +57,6 @@ public final class ContextManagers {
      * This snapshot is returned as a single object that can be temporarily
      * {@link ContextSnapshot#reactivate() reactivated}. Don't forget to {@link Context#close() close} the reactivated
      * context once you're done, preferably in a <code>try-with-resources</code> construct.
-     * <p>
-     * <strong>Note about propagation accross physical node boundaries:</strong>
-     * <em>ContextSnapshot instances can be serialized to and reactivated on another node under strict conditions:</em>
-     * <ol>
-     * <li><strong>All</strong> {@link Context#getValue() context values} <strong>must</strong> be serializable.</li>
-     * <li>All {@link ContextManager} implementations that contain
-     * {@link ContextManager#getActiveContext() active contexts} must be registered on the target node as well
-     * (but need not be serializable themselves).</li>
-     * </ol>
      *
      * @return A new snapshot that can be reactivated elsewhere (e.g. a background thread or even another node)
      * within a try-with-resources construct.
@@ -182,11 +172,8 @@ public final class ContextManagers {
     /**
      * Implementation of the <code>createContextSnapshot</code> functionality that can reactivate all values from the
      * snapshot in each corresponding {@link ContextManager}.
-     * <p>
-     * This class is only really {@link Serializable} if all captured {@link Context#getValue() values} are
-     * serializable as well. The {@link ContextManager} implementations do not need to be {@link Serializable}.
      */
-    private static final class ContextSnapshotImpl implements ContextSnapshot, Serializable {
+    private static final class ContextSnapshotImpl implements ContextSnapshot {
         private static final ContextManager[] MANAGER_ARRAY = new ContextManager[0];
         private final ContextManager[] managers;
         private final Object[] values;


### PR DESCRIPTION
Hopefully this simplification of the `ContextSnapshot` fixes #94 about the classloading issue in Spring Boot using Java 11 and the `ForkJoinPool.commonPool()` caused by the difference between the System classloader (used by the snapshot, from fork-join pool) and the spring boot application classloader (used to _take_ the snapshot).