### PR TITLE
Don't take new snapshot after runAsync or supplyAsync by default

### DIFF
--- a/context-propagation-java8/src/test/java/nl/talsmasoftware/context/futures/ContextAwareCompletableFutureTest.java
+++ b/context-propagation-java8/src/test/java/nl/talsmasoftware/context/futures/ContextAwareCompletableFutureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Talsma ICT
+ * Copyright 2016-2019 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,8 +36,8 @@ import java.util.concurrent.TimeoutException;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isOneOf;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.oneOf;
 import static org.hamcrest.Matchers.startsWith;
 
 /**
@@ -72,55 +72,71 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testSupplyAsync() throws ExecutionException, InterruptedException {
-        String expectedValue = "Vincent Vega";
-        try (Context<String> ctx = manager.initializeNewContext(expectedValue)) {
+        try (Context<String> ctx = manager.initializeNewContext("Vincent Vega")) {
             Future<Optional<String>> future = ContextAwareCompletableFuture
                     .supplyAsync(DummyContextManager::currentValue);
-            assertThat(future.get().get(), is(expectedValue));
+            assertThat(future.get().get(), is("Vincent Vega"));
         }
     }
 
     @Test
     public void testSupplyAsync_executor() throws ExecutionException, InterruptedException {
-        String expectedValue = "Marcellus Wallace";
-        try (Context<String> ctx = manager.initializeNewContext(expectedValue)) {
+        try (Context<String> ctx = manager.initializeNewContext("Marcellus Wallace")) {
             Future<Optional<String>> future = ContextAwareCompletableFuture
                     .supplyAsync(DummyContextManager::currentValue, contextUnawareThreadpool);
-            assertThat(future.get().get(), is(expectedValue));
+            assertThat(future.get().get(), is("Marcellus Wallace"));
         }
-
     }
 
     @Test
     public void testSupplyAsync_executor_snapshot() throws ExecutionException, InterruptedException {
-        String expectedValue = "Vincent Vega";
-        try (Context<String> ctx = manager.initializeNewContext(expectedValue)) {
+        try (Context<String> ctx = manager.initializeNewContext("Vincent Vega")) {
             ContextSnapshot snapshot = ContextManagers.createContextSnapshot();
             manager.initializeNewContext("Jules Winnfield");
             assertThat(manager.getActiveContext().getValue(), is("Jules Winnfield"));
 
             Future<Optional<String>> future = ContextAwareCompletableFuture
                     .supplyAsync(DummyContextManager::currentValue, contextUnawareThreadpool, snapshot);
-            assertThat(future.get().get(), is(expectedValue));
+            assertThat(future.get().get(), is("Vincent Vega"));
+        }
+    }
+
+    @Test
+    public void testSupplyAsync_executor_snapshot_takeNewSnapshot() throws ExecutionException, InterruptedException {
+        try (Context<String> ctx = manager.initializeNewContext("Vincent Vega")) {
+            ContextSnapshot snapshot = ContextManagers.createContextSnapshot();
+            manager.initializeNewContext("Jules Winnfield");
+            assertThat(manager.getActiveContext().getValue(), is("Jules Winnfield"));
+
+            ContextAwareCompletableFuture<Optional<String>> future = ContextAwareCompletableFuture
+                    .supplyAsync(() -> {
+                        try {
+                            return DummyContextManager.currentValue();
+                        } finally {
+                            DummyContextManager.setCurrentValue("Marcellus Wallace");
+                        }
+                    }, contextUnawareThreadpool, snapshot, true);
+
+            assertThat(future.get(), is(Optional.of("Vincent Vega")));
+            assertThat(future.thenApply(x -> DummyContextManager.currentValue()).get(),
+                    is(Optional.of("Marcellus Wallace")));
         }
     }
 
     @Test
     public void testRunAsync() throws ExecutionException, InterruptedException {
-        String expectedValue = "Mia Wallace";
-        try (Context<String> ctx = manager.initializeNewContext(expectedValue)) {
+        try (Context<String> ctx = manager.initializeNewContext("Mia Wallace")) {
             ContextAwareCompletableFuture<Void> future = ContextAwareCompletableFuture
-                    .runAsync(() -> assertThat(DummyContextManager.currentValue(), is(Optional.of(expectedValue))));
+                    .runAsync(() -> assertThat(DummyContextManager.currentValue(), is(Optional.of("Mia Wallace"))));
             future.get(); // trigger asynchronous assertion
         }
     }
 
     @Test
     public void testRunAsync_executor() throws ExecutionException, InterruptedException {
-        String expectedValue = "Jimmie";
-        try (Context<String> ctx = manager.initializeNewContext(expectedValue)) {
+        try (Context<String> ctx = manager.initializeNewContext("Jimmie")) {
             ContextAwareCompletableFuture<Void> future = ContextAwareCompletableFuture.runAsync(
-                    () -> assertThat(DummyContextManager.currentValue(), is(Optional.of(expectedValue))),
+                    () -> assertThat(DummyContextManager.currentValue(), is(Optional.of("Jimmie"))),
                     contextUnawareThreadpool);
             future.get(); // trigger asynchronous assertion
         }
@@ -128,17 +144,39 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testRunAsync_executor_snapshot() throws ExecutionException, InterruptedException {
-        String expectedValue = "Pumpkin";
-        try (Context<String> ctx = manager.initializeNewContext(expectedValue)) {
+        try (Context<String> ctx = manager.initializeNewContext("Pumpkin")) {
             ContextSnapshot snapshot = ContextManagers.createContextSnapshot();
             manager.initializeNewContext("Honey Bunny");
             assertThat(manager.getActiveContext().getValue(), is("Honey Bunny"));
 
             ContextAwareCompletableFuture<Void> future = ContextAwareCompletableFuture.runAsync(
-                    () -> assertThat(DummyContextManager.currentValue(), is(Optional.of(expectedValue))),
+                    () -> assertThat(DummyContextManager.currentValue(), is(Optional.of("Pumpkin"))),
                     contextUnawareThreadpool,
                     snapshot);
             future.get(); // trigger asynchronous assertion
+        }
+    }
+
+    @Test
+    public void testRunAsync_executor_snapshot_takeNewSnapshot() throws ExecutionException, InterruptedException {
+        try (Context<String> ctx = manager.initializeNewContext("Pumpkin")) {
+            ContextSnapshot snapshot = ContextManagers.createContextSnapshot();
+            manager.initializeNewContext("Honey Bunny");
+            assertThat(manager.getActiveContext().getValue(), is("Honey Bunny"));
+
+            ContextAwareCompletableFuture<Void> future = ContextAwareCompletableFuture.runAsync(
+                    () -> {
+                        try {
+                            assertThat(DummyContextManager.currentValue(), is(Optional.of("Pumpkin")));
+                        } finally {
+                            DummyContextManager.setCurrentValue("Bad Motherfucker");
+                        }
+                    },
+                    contextUnawareThreadpool,
+                    snapshot,
+                    true);
+            future.get(); // trigger asynchronous assertion
+            future.thenRun(() -> assertThat(DummyContextManager.currentValue(), is(Optional.of("Bad Motherfucker")))).get();
         }
     }
 
@@ -148,7 +186,14 @@ public class ContextAwareCompletableFutureTest {
             Future<Optional<String>> future = ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Bonnie"))
                     .thenApply(voidvalue -> DummyContextManager.currentValue());
-            assertThat(future.get().get(), is("Bonnie"));
+            assertThat(future.get(), is(Optional.of("Jimmie")));
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Jimmie")) {
+            Future<Optional<String>> future = ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Bonnie"), null, null, true)
+                    .thenApply(voidvalue -> DummyContextManager.currentValue());
+            assertThat(future.get(), is(Optional.of("Bonnie")));
         }
     }
 
@@ -157,6 +202,13 @@ public class ContextAwareCompletableFutureTest {
         try (Context<String> ctx = manager.initializeNewContext("Butch")) {
             Future<Optional<String>> future = ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Esmerelda Villalobos"))
+                    .thenApplyAsync(voidvalue -> DummyContextManager.currentValue());
+            assertThat(future.get().get(), is("Butch"));
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Butch")) {
+            Future<Optional<String>> future = ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Esmerelda Villalobos"), null, null, true)
                     .thenApplyAsync(voidvalue -> DummyContextManager.currentValue());
             assertThat(future.get().get(), is("Esmerelda Villalobos"));
         }
@@ -168,6 +220,13 @@ public class ContextAwareCompletableFutureTest {
             Future<Optional<String>> future = ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Zed"))
                     .thenApplyAsync(voidvalue -> DummyContextManager.currentValue(), contextUnawareThreadpool);
+            assertThat(future.get().get(), is("Maynard"));
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Maynard")) {
+            Future<Optional<String>> future = ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Zed"), null, null, true)
+                    .thenApplyAsync(voidvalue -> DummyContextManager.currentValue(), contextUnawareThreadpool);
             assertThat(future.get().get(), is("Zed"));
         }
     }
@@ -178,6 +237,21 @@ public class ContextAwareCompletableFutureTest {
             ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Bonnie"))
                     .takeNewSnapshot()
+                    .thenApply(voidvalue -> {
+                        String val = DummyContextManager.currentValue().get();
+                        manager.initializeNewContext("-" + val);
+                        return val;
+                    })
+                    .thenAccept(s -> {
+                        assertThat(s, is("Jimmie"));
+                        assertThat(DummyContextManager.currentValue(), is(Optional.of("-Jimmie")));
+                    })
+                    .get();
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Jimmie")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Bonnie"), null, null, true)
                     .thenApply(voidvalue -> {
                         String val = DummyContextManager.currentValue().get();
                         manager.initializeNewContext("-" + val);
@@ -203,6 +277,21 @@ public class ContextAwareCompletableFutureTest {
                         return val;
                     })
                     .thenAccept(s -> {
+                        assertThat(s, is("Butch"));
+                        assertThat(DummyContextManager.currentValue(), is(Optional.of("-Butch")));
+                    })
+                    .get();
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Butch")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Esmerelda Villalobos"), null, null, true)
+                    .thenApplyAsync(voidvalue -> {
+                        String val = DummyContextManager.currentValue().get();
+                        manager.initializeNewContext("-" + val);
+                        return val;
+                    })
+                    .thenAccept(s -> {
                         assertThat(s, is("Esmerelda Villalobos"));
                         assertThat(DummyContextManager.currentValue(), is(Optional.of("-Esmerelda Villalobos")));
                     })
@@ -222,6 +311,21 @@ public class ContextAwareCompletableFutureTest {
                         return val;
                     }, contextUnawareThreadpool)
                     .thenAccept(s -> {
+                        assertThat(s, is("Maynard"));
+                        assertThat(DummyContextManager.currentValue(), is(Optional.of("-Maynard")));
+                    })
+                    .get();
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Maynard")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Zed"), null, null, true)
+                    .thenApplyAsync(voidvalue -> {
+                        String val = DummyContextManager.currentValue().get();
+                        manager.initializeNewContext("-" + val);
+                        return val;
+                    }, contextUnawareThreadpool)
+                    .thenAccept(s -> {
                         assertThat(s, is("Zed"));
                         assertThat(DummyContextManager.currentValue(), is(Optional.of("-Zed")));
                     })
@@ -234,6 +338,13 @@ public class ContextAwareCompletableFutureTest {
         try (Context<String> ctx = manager.initializeNewContext("The Gimp")) {
             Future<Void> future = ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Butch"))
+                    .thenAccept(voidvalue -> assertThat(DummyContextManager.currentValue(), is(Optional.of("The Gimp"))));
+            future.get(); // trigger asynchronous assertion
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("The Gimp")) {
+            Future<Void> future = ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Butch"), null, null, true)
                     .thenAccept(voidvalue -> assertThat(DummyContextManager.currentValue(), is(Optional.of("Butch"))));
             future.get(); // trigger asynchronous assertion
         }
@@ -244,6 +355,13 @@ public class ContextAwareCompletableFutureTest {
         try (Context<String> ctx = manager.initializeNewContext("Butch")) {
             Future<Void> future = ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Fabienne"))
+                    .thenAcceptAsync(voidvalue -> assertThat(DummyContextManager.currentValue(), is(Optional.of("Butch"))));
+            future.get(); // trigger asynchronous assertion
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Butch")) {
+            Future<Void> future = ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Fabienne"), null, null, true)
                     .thenAcceptAsync(voidvalue -> assertThat(DummyContextManager.currentValue(), is(Optional.of("Fabienne"))));
             future.get(); // trigger asynchronous assertion
         }
@@ -255,7 +373,16 @@ public class ContextAwareCompletableFutureTest {
             Future<Void> future = ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Winston Wolfe"))
                     .thenAcceptAsync(
-                            voidvalue -> assertThat(DummyContextManager.currentValue().get(), is("Winston Wolfe")),
+                            voidvalue -> assertThat(DummyContextManager.currentValue(), is(Optional.of("Marvin"))),
+                            contextUnawareThreadpool);
+            future.get(); // trigger asynchronous assertion
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Marvin")) {
+            Future<Void> future = ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Winston Wolfe"), null, null, true)
+                    .thenAcceptAsync(
+                            voidvalue -> assertThat(DummyContextManager.currentValue(), is(Optional.of("Winston Wolfe"))),
                             contextUnawareThreadpool);
             future.get(); // trigger asynchronous assertion
         }
@@ -267,6 +394,18 @@ public class ContextAwareCompletableFutureTest {
             ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Butch"))
                     .takeNewSnapshot()
+                    .thenAccept(voidvalue -> {
+                        String val = DummyContextManager.currentValue().get();
+                        assertThat(val, is("The Gimp"));
+                        manager.initializeNewContext("-" + val);
+                    })
+                    .thenAccept(aVoid -> assertThat(DummyContextManager.currentValue(), is(Optional.of("-The Gimp"))))
+                    .get(); // trigger asynchronous assertion
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("The Gimp")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Butch"), null, null, true)
                     .thenAccept(voidvalue -> {
                         String val = DummyContextManager.currentValue().get();
                         assertThat(val, is("Butch"));
@@ -283,6 +422,18 @@ public class ContextAwareCompletableFutureTest {
             ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Fabienne"))
                     .takeNewSnapshot()
+                    .thenAcceptAsync(voidvalue -> {
+                        String val = DummyContextManager.currentValue().get();
+                        assertThat(val, is("Butch"));
+                        manager.initializeNewContext("-" + val);
+                    })
+                    .thenAccept(aVoid -> assertThat(DummyContextManager.currentValue(), is(Optional.of("-Butch"))))
+                    .get(); // trigger asynchronous assertion
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Butch")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Fabienne"), null, null, true)
                     .thenAcceptAsync(voidvalue -> {
                         String val = DummyContextManager.currentValue().get();
                         assertThat(val, is("Fabienne"));
@@ -302,6 +453,20 @@ public class ContextAwareCompletableFutureTest {
                     .thenAcceptAsync(
                             voidvalue -> {
                                 String val = DummyContextManager.currentValue().get();
+                                assertThat(val, is("Marvin"));
+                                manager.initializeNewContext("-" + val);
+                            },
+                            contextUnawareThreadpool)
+                    .thenAccept(aVoid -> assertThat(DummyContextManager.currentValue(), is(Optional.of("-Marvin"))))
+                    .get(); // trigger asynchronous assertion
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Marvin")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Winston Wolfe"), null, null, true)
+                    .thenAcceptAsync(
+                            voidvalue -> {
+                                String val = DummyContextManager.currentValue().get();
                                 assertThat(val, is("Winston Wolfe"));
                                 manager.initializeNewContext("-" + val);
                             },
@@ -316,6 +481,13 @@ public class ContextAwareCompletableFutureTest {
         try (Context<String> ctx = manager.initializeNewContext("Lance")) {
             Future<Void> future = ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Jody"))
+                    .thenRun(() -> assertThat(DummyContextManager.currentValue(), is(Optional.of("Lance"))));
+            future.get(); // trigger asynchronous assertion
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Lance")) {
+            Future<Void> future = ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Jody"), null, null, true)
                     .thenRun(() -> assertThat(DummyContextManager.currentValue(), is(Optional.of("Jody"))));
             future.get(); // trigger asynchronous assertion
         }
@@ -326,6 +498,13 @@ public class ContextAwareCompletableFutureTest {
         try (Context<String> ctx = manager.initializeNewContext("Ringo")) {
             Future<Void> future = ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Yolanda"))
+                    .thenRunAsync(() -> assertThat(DummyContextManager.currentValue(), is(Optional.of("Ringo"))));
+            future.get(); // trigger asynchronous assertion
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Ringo")) {
+            Future<Void> future = ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Yolanda"), null, null, true)
                     .thenRunAsync(() -> assertThat(DummyContextManager.currentValue(), is(Optional.of("Yolanda"))));
             future.get(); // trigger asynchronous assertion
         }
@@ -336,6 +515,15 @@ public class ContextAwareCompletableFutureTest {
         try (Context<String> ctx = manager.initializeNewContext("Capt. Koons")) {
             Future<Void> future = ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Butch"))
+                    .thenRunAsync(
+                            () -> assertThat(DummyContextManager.currentValue(), is(Optional.of("Capt. Koons"))),
+                            contextUnawareThreadpool);
+            future.get(); // trigger asynchronous assertion
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Capt. Koons")) {
+            Future<Void> future = ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Butch"), null, null, true)
                     .thenRunAsync(
                             () -> assertThat(DummyContextManager.currentValue(), is(Optional.of("Butch"))),
                             contextUnawareThreadpool);
@@ -349,6 +537,18 @@ public class ContextAwareCompletableFutureTest {
             ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Jody"))
                     .takeNewSnapshot()
+                    .thenRun(() -> {
+                        String val = DummyContextManager.currentValue().get();
+                        assertThat(val, is("Lance"));
+                        manager.initializeNewContext("-" + val);
+                    })
+                    .thenAccept(aVoid -> assertThat(DummyContextManager.currentValue(), is(Optional.of("-Lance"))))
+                    .get(); // trigger asynchronous assertion
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Lance")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Jody"), null, null, true)
                     .thenRun(() -> {
                         String val = DummyContextManager.currentValue().get();
                         assertThat(val, is("Jody"));
@@ -365,6 +565,18 @@ public class ContextAwareCompletableFutureTest {
             ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Yolanda"))
                     .takeNewSnapshot()
+                    .thenRunAsync(() -> {
+                        String val = DummyContextManager.currentValue().get();
+                        assertThat(val, is("Ringo"));
+                        manager.initializeNewContext("-" + val);
+                    })
+                    .thenAccept(aVoid -> assertThat(DummyContextManager.currentValue(), is(Optional.of("-Ringo"))))
+                    .get(); // trigger asynchronous assertion
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Ringo")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Yolanda"), null, null, true)
                     .thenRunAsync(() -> {
                         String val = DummyContextManager.currentValue().get();
                         assertThat(val, is("Yolanda"));
@@ -384,6 +596,20 @@ public class ContextAwareCompletableFutureTest {
                     .thenRunAsync(
                             () -> {
                                 String val = DummyContextManager.currentValue().get();
+                                assertThat(val, is("Capt. Koons"));
+                                manager.initializeNewContext("-" + val);
+                            },
+                            contextUnawareThreadpool)
+                    .thenAccept(aVoid -> assertThat(DummyContextManager.currentValue(), is(Optional.of("-Capt. Koons"))))
+                    .get(); // trigger asynchronous assertion
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Capt. Koons")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Butch"), null, null, true)
+                    .thenRunAsync(
+                            () -> {
+                                String val = DummyContextManager.currentValue().get();
                                 assertThat(val, is("Butch"));
                                 manager.initializeNewContext("-" + val);
                             },
@@ -398,6 +624,13 @@ public class ContextAwareCompletableFutureTest {
         try (Context<String> ctx = manager.initializeNewContext("Butch")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Floyd"))
+                    .whenComplete((voidValue, exception) -> assertThat(DummyContextManager.currentValue(), is(Optional.of("Butch"))))
+                    .get(); // trigger asynchronous assertion
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Butch")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Floyd"), null, null, true)
                     .whenComplete((voidValue, exception) -> assertThat(DummyContextManager.currentValue(), is(Optional.of("Floyd"))))
                     .get(); // trigger asynchronous assertion
         }
@@ -408,6 +641,13 @@ public class ContextAwareCompletableFutureTest {
         try (Context<String> ctx = manager.initializeNewContext("Zed")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Pipe hittin' niggers"))
+                    .whenCompleteAsync((voidValue, exception) -> assertThat(DummyContextManager.currentValue(), is(Optional.of("Zed"))))
+                    .get(); // trigger asynchronous assertion
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Zed")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Pipe hittin' niggers"), null, null, true)
                     .whenCompleteAsync((voidValue, exception) -> assertThat(DummyContextManager.currentValue(), is(Optional.of("Pipe hittin' niggers"))))
                     .get(); // trigger asynchronous assertion
         }
@@ -418,6 +658,15 @@ public class ContextAwareCompletableFutureTest {
         try (Context<String> ctx = manager.initializeNewContext("Butch")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Floyd"))
+                    .whenCompleteAsync(
+                            (voidValue, exception) -> assertThat(DummyContextManager.currentValue(), is(Optional.of("Butch"))),
+                            contextUnawareThreadpool)
+                    .get(); // trigger asynchronous assertion
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Butch")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Floyd"), null, null, true)
                     .whenCompleteAsync(
                             (voidValue, exception) -> assertThat(DummyContextManager.currentValue(), is(Optional.of("Floyd"))),
                             contextUnawareThreadpool)
@@ -436,6 +685,17 @@ public class ContextAwareCompletableFutureTest {
                             })
                             .handleAsync((voidValue, throwable) -> manager.getActiveContext().getValue())
                             .get(),
+                    is("Jody"));
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Jody")) {
+            assertThat(ContextAwareCompletableFuture
+                            .runAsync(() -> {
+                                manager.initializeNewContext("Trudy");
+                                throw exception;
+                            }, null, null, true)
+                            .handleAsync((voidValue, throwable) -> manager.getActiveContext().getValue())
+                            .get(),
                     is("Trudy"));
         }
     }
@@ -449,6 +709,17 @@ public class ContextAwareCompletableFutureTest {
                                 manager.initializeNewContext("Trudy");
                                 throw exception;
                             })
+                            .handleAsync((voidValue, throwable) -> manager.getActiveContext().getValue())
+                            .get(),
+                    is("Jody"));
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Jody")) {
+            assertThat(ContextAwareCompletableFuture
+                            .runAsync(() -> {
+                                manager.initializeNewContext("Trudy");
+                                throw exception;
+                            }, null, null, true)
                             .handleAsync((voidValue, throwable) -> manager.getActiveContext().getValue())
                             .get(),
                     is("Trudy"));
@@ -468,6 +739,19 @@ public class ContextAwareCompletableFutureTest {
                                     (voidValue, throwable) -> manager.getActiveContext().getValue(),
                                     contextUnawareThreadpool)
                             .get(),
+                    is("Jody"));
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Jody")) {
+            assertThat(ContextAwareCompletableFuture
+                            .runAsync(() -> {
+                                manager.initializeNewContext("Trudy");
+                                throw exception;
+                            }, null, null, true)
+                            .handleAsync(
+                                    (voidValue, throwable) -> manager.getActiveContext().getValue(),
+                                    contextUnawareThreadpool)
+                            .get(),
                     is("Trudy"));
         }
     }
@@ -482,6 +766,22 @@ public class ContextAwareCompletableFutureTest {
                                 throw exception;
                             })
                             .takeNewSnapshot()
+                            .handle((voidValue, throwable) -> {
+                                String val = manager.getActiveContext().getValue();
+                                manager.initializeNewContext("-" + val);
+                                return val;
+                            })
+                            .whenComplete((result, throwable) -> assertThat(manager.getActiveContext().getValue(), is("-Jody")))
+                            .get(),
+                    is("Jody"));
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Jody")) {
+            assertThat(ContextAwareCompletableFuture
+                            .runAsync(() -> {
+                                manager.initializeNewContext("Trudy");
+                                throw exception;
+                            }, null, null, true)
                             .handle((voidValue, throwable) -> {
                                 String val = manager.getActiveContext().getValue();
                                 manager.initializeNewContext("-" + val);
@@ -508,6 +808,22 @@ public class ContextAwareCompletableFutureTest {
                                 manager.initializeNewContext("-" + val);
                                 return val;
                             })
+                            .whenComplete((result, throwable) -> assertThat(manager.getActiveContext().getValue(), is("-Jody")))
+                            .get(),
+                    is("Jody"));
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Jody")) {
+            assertThat(ContextAwareCompletableFuture
+                            .runAsync(() -> {
+                                manager.initializeNewContext("Trudy");
+                                throw exception;
+                            }, null, null, true)
+                            .handleAsync((voidValue, throwable) -> {
+                                String val = manager.getActiveContext().getValue();
+                                manager.initializeNewContext("-" + val);
+                                return val;
+                            })
                             .whenComplete((result, throwable) -> assertThat(manager.getActiveContext().getValue(), is("-Trudy")))
                             .get(),
                     is("Trudy"));
@@ -529,6 +845,22 @@ public class ContextAwareCompletableFutureTest {
                                 manager.initializeNewContext("-" + val);
                                 return val;
                             }, contextUnawareThreadpool)
+                            .whenComplete((result, throwable) -> assertThat(manager.getActiveContext().getValue(), is("-Jody")))
+                            .get(),
+                    is("Jody"));
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Jody")) {
+            assertThat(ContextAwareCompletableFuture
+                            .runAsync(() -> {
+                                manager.initializeNewContext("Trudy");
+                                throw exception;
+                            }, null, null, true)
+                            .handleAsync((voidValue, throwable) -> {
+                                String val = manager.getActiveContext().getValue();
+                                manager.initializeNewContext("-" + val);
+                                return val;
+                            }, contextUnawareThreadpool)
                             .whenComplete((result, throwable) -> assertThat(manager.getActiveContext().getValue(), is("-Trudy")))
                             .get(),
                     is("Trudy"));
@@ -543,6 +875,20 @@ public class ContextAwareCompletableFutureTest {
                         manager.initializeNewContext("Jules Winnfield");
                         throw new RuntimeException("Bad Motherfucker");
                     })
+                    .exceptionally(ex -> {
+                        String val = manager.getActiveContext().getValue();
+                        assertThat(val, is("Gringo"));
+                        return null;
+                    })
+                    .get();
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Gringo")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> {
+                        manager.initializeNewContext("Jules Winnfield");
+                        throw new RuntimeException("Bad Motherfucker");
+                    }, null, null, true)
                     .exceptionally(ex -> {
                         String val = manager.getActiveContext().getValue();
                         assertThat(val, is("Jules Winnfield"));
@@ -563,6 +909,22 @@ public class ContextAwareCompletableFutureTest {
                     .takeNewSnapshot()
                     .exceptionally(ex -> {
                         String val = manager.getActiveContext().getValue();
+                        assertThat(val, is("Gringo"));
+                        manager.initializeNewContext("-" + val);
+                        return null;
+                    })
+                    .thenAccept(aVoid -> assertThat(manager.getActiveContext().getValue(), is("-Gringo")))
+                    .get();
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Gringo")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> {
+                        manager.initializeNewContext("Jules Winnfield");
+                        throw new RuntimeException("Bad Motherfucker");
+                    }, null, null, true)
+                    .exceptionally(ex -> {
+                        String val = manager.getActiveContext().getValue();
                         assertThat(val, is("Jules Winnfield"));
                         manager.initializeNewContext("-" + val);
                         return null;
@@ -580,6 +942,16 @@ public class ContextAwareCompletableFutureTest {
                     .thenCombine(
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Jules Winnfield")),
                             (voidA, voidB) -> DummyContextManager.currentValue());
+            assertThat(future.get(), is(Optional.of("Marcellus Wallace")));
+            assertThat(DummyContextManager.currentValue(), is(Optional.of("Marcellus Wallace")));
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Marcellus Wallace")) {
+            Future<Optional<String>> future = ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Vincent Vega"), null, null, true)
+                    .thenCombine(
+                            ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Jules Winnfield")),
+                            (voidA, voidB) -> DummyContextManager.currentValue());
             assertThat(future.get(), is(Optional.of("Vincent Vega")));
             assertThat(DummyContextManager.currentValue(), is(Optional.of("Marcellus Wallace")));
         }
@@ -593,6 +965,16 @@ public class ContextAwareCompletableFutureTest {
                     .thenCombineAsync(
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Flock of Seagulls")),
                             (voidA, voidB) -> DummyContextManager.currentValue());
+            assertThat(future.get(), is(Optional.of("Brett")));
+            assertThat(DummyContextManager.currentValue(), is(Optional.of("Brett")));
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Brett")) {
+            Future<Optional<String>> future = ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Marvin"), null, null, true)
+                    .thenCombineAsync(
+                            ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Flock of Seagulls")),
+                            (voidA, voidB) -> DummyContextManager.currentValue());
             assertThat(future.get(), is(Optional.of("Marvin")));
             assertThat(DummyContextManager.currentValue(), is(Optional.of("Brett")));
         }
@@ -603,6 +985,17 @@ public class ContextAwareCompletableFutureTest {
         try (Context<String> ctx = manager.initializeNewContext("Brett")) {
             Future<Optional<String>> future = ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Marvin"))
+                    .thenCombineAsync(
+                            ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Flock of Seagulls")),
+                            (voidA, voidB) -> DummyContextManager.currentValue(),
+                            contextUnawareThreadpool);
+            assertThat(future.get(), is(Optional.of("Brett")));
+            assertThat(DummyContextManager.currentValue(), is(Optional.of("Brett")));
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Brett")) {
+            Future<Optional<String>> future = ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Marvin"), null, null, true)
                     .thenCombineAsync(
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Flock of Seagulls")),
                             (voidA, voidB) -> DummyContextManager.currentValue(),
@@ -625,6 +1018,21 @@ public class ContextAwareCompletableFutureTest {
                                 manager.initializeNewContext("-" + val);
                                 return val;
                             })
+                    .whenComplete((result, exception) -> assertThat(DummyContextManager.currentValue(), is(Optional.of("-Marcellus Wallace"))));
+
+            assertThat(future.get(), is("Marcellus Wallace"));
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Marcellus Wallace")) {
+            Future<String> future = ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Vincent Vega"), null, null, true)
+                    .thenCombine(
+                            ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Jules Winnfield")),
+                            (voidA, voidB) -> {
+                                String val = DummyContextManager.currentValue().get();
+                                manager.initializeNewContext("-" + val);
+                                return val;
+                            })
                     .whenComplete((result, exception) -> assertThat(DummyContextManager.currentValue(), is(Optional.of("-Vincent Vega"))));
 
             assertThat(future.get(), is("Vincent Vega"));
@@ -637,6 +1045,22 @@ public class ContextAwareCompletableFutureTest {
             Future<String> future = ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Marvin"))
                     .takeNewSnapshot()
+                    .thenCombineAsync(
+                            ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Flock of Seagulls")),
+                            (voidA, voidB) -> {
+                                String val = DummyContextManager.currentValue().get();
+                                manager.initializeNewContext("-" + val);
+                                return val;
+                            })
+                    .whenComplete((result, exeption) -> assertThat(DummyContextManager.currentValue(), is(Optional.of("-Brett"))));
+
+            assertThat(future.get(), is("Brett"));
+            assertThat(DummyContextManager.currentValue(), is(Optional.of("Brett")));
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Brett")) {
+            Future<String> future = ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Marvin"), null, null, true)
                     .thenCombineAsync(
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Flock of Seagulls")),
                             (voidA, voidB) -> {
@@ -665,6 +1089,23 @@ public class ContextAwareCompletableFutureTest {
                                 return val;
                             },
                             contextUnawareThreadpool)
+                    .whenComplete((result, exeption) -> assertThat(DummyContextManager.currentValue(), is(Optional.of("-Brett"))));
+
+            assertThat(future.get(), is("Brett"));
+            assertThat(DummyContextManager.currentValue(), is(Optional.of("Brett")));
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Brett")) {
+            Future<String> future = ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Marvin"), null, null, true)
+                    .thenCombineAsync(
+                            ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Flock of Seagulls")),
+                            (voidA, voidB) -> {
+                                String val = DummyContextManager.currentValue().get();
+                                manager.initializeNewContext("-" + val);
+                                return val;
+                            },
+                            contextUnawareThreadpool)
                     .whenComplete((result, exeption) -> assertThat(DummyContextManager.currentValue(), is(Optional.of("-Marvin"))));
 
             assertThat(future.get(), is("Marvin"));
@@ -676,12 +1117,13 @@ public class ContextAwareCompletableFutureTest {
     public void testThenAcceptBoth() throws ExecutionException, InterruptedException {
         try (Context<String> ctx = manager.initializeNewContext("Pulp Fiction")) {
             ContextAwareCompletableFuture
-                    .runAsync(() -> manager.initializeNewContext("Quentin").getValue())
+                    .runAsync(() -> manager.initializeNewContext("Quentin").getValue(), null, null, true)
                     .thenAcceptBoth(completedFuture("Tarantino"),
                             (Void voidA, String stringB) ->
                                     assertThat(manager.getActiveContext().getValue() + stringB,
                                             is("QuentinTarantino")))
                     .get();
+            assertThat(DummyContextManager.currentValue(), is(Optional.of("Pulp Fiction")));
         }
     }
 
@@ -689,12 +1131,13 @@ public class ContextAwareCompletableFutureTest {
     public void testThenAcceptBothAsync() throws ExecutionException, InterruptedException {
         try (Context<String> ctx = manager.initializeNewContext("Pulp Fiction")) {
             ContextAwareCompletableFuture
-                    .runAsync(() -> manager.initializeNewContext("Quentin").getValue())
+                    .runAsync(() -> manager.initializeNewContext("Quentin").getValue(), null, null, true)
                     .thenAcceptBothAsync(completedFuture("Tarantino"),
                             (Void voidA, String stringB) ->
                                     assertThat(manager.getActiveContext().getValue() + stringB,
                                             is("QuentinTarantino")))
                     .get();
+            assertThat(DummyContextManager.currentValue(), is(Optional.of("Pulp Fiction")));
         }
     }
 
@@ -702,13 +1145,14 @@ public class ContextAwareCompletableFutureTest {
     public void testThenAcceptBothAsync_executor() throws ExecutionException, InterruptedException {
         try (Context<String> ctx = manager.initializeNewContext("Pulp Fiction")) {
             ContextAwareCompletableFuture
-                    .runAsync(() -> manager.initializeNewContext("Quentin").getValue())
+                    .runAsync(() -> manager.initializeNewContext("Quentin").getValue(), null, null, true)
                     .thenAcceptBothAsync(completedFuture("Tarantino"),
                             (Void voidA, String stringB) ->
                                     assertThat(manager.getActiveContext().getValue() + stringB,
                                             is("QuentinTarantino")),
                             contextUnawareThreadpool)
                     .get();
+            assertThat(DummyContextManager.currentValue(), is(Optional.of("Pulp Fiction")));
         }
     }
 
@@ -718,13 +1162,26 @@ public class ContextAwareCompletableFutureTest {
             ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Quentin").getValue())
                     .takeNewSnapshot()
-                    .thenAcceptBoth(completedFuture("Tarantino"),
+                    .thenAcceptBoth(completedFuture(" by Tarantino"),
                             (Void voidA, String stringB) -> {
                                 String val = manager.getActiveContext().getValue() + stringB;
-                                assertThat(val, is("QuentinTarantino"));
+                                assertThat(val, is("Pulp Fiction by Tarantino"));
                                 manager.initializeNewContext("-" + val);
                             })
-                    .thenAccept(aVoid -> assertThat(manager.getActiveContext().getValue(), is("-QuentinTarantino")))
+                    .thenAccept(aVoid -> assertThat(manager.getActiveContext().getValue(), is("-Pulp Fiction by Tarantino")))
+                    .get();
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Pulp Fiction")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Quentin").getValue(), null, null, true)
+                    .thenAcceptBoth(completedFuture(" by Tarantino"),
+                            (Void voidA, String stringB) -> {
+                                String val = manager.getActiveContext().getValue() + stringB;
+                                assertThat(val, is("Quentin by Tarantino"));
+                                manager.initializeNewContext("-" + val);
+                            })
+                    .thenAccept(aVoid -> assertThat(manager.getActiveContext().getValue(), is("-Quentin by Tarantino")))
                     .get();
         }
     }
@@ -735,6 +1192,19 @@ public class ContextAwareCompletableFutureTest {
             ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Quentin").getValue())
                     .takeNewSnapshot()
+                    .thenAcceptBoth(completedFuture(" by Tarantino"),
+                            (Void voidA, String stringB) -> {
+                                String val = manager.getActiveContext().getValue() + stringB;
+                                assertThat(val, is("Pulp Fiction by Tarantino"));
+                                manager.initializeNewContext("-" + val);
+                            })
+                    .thenAccept(aVoid -> assertThat(manager.getActiveContext().getValue(), is("-Pulp Fiction by Tarantino")))
+                    .get();
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Pulp Fiction")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Quentin").getValue(), null, null, true)
                     .thenAcceptBoth(completedFuture("Tarantino"),
                             (Void voidA, String stringB) -> {
                                 String val = manager.getActiveContext().getValue() + stringB;
@@ -752,6 +1222,21 @@ public class ContextAwareCompletableFutureTest {
             ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Quentin").getValue())
                     .takeNewSnapshot()
+                    .thenAcceptBothAsync(completedFuture(" by Tarantino"),
+                            (Void voidA, String stringB) -> {
+                                String val = manager.getActiveContext().getValue() + stringB;
+                                assertThat(val, is("Pulp Fiction by Tarantino"));
+                                manager.initializeNewContext("-" + val);
+                            },
+                            contextUnawareThreadpool)
+                    .thenAccept(aVoid -> assertThat(manager.getActiveContext().getValue(), is("-Pulp Fiction by Tarantino")))
+                    .get();
+            assertThat(manager.getActiveContext().getValue(), is("Pulp Fiction"));
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Pulp Fiction")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Quentin").getValue(), null, null, true)
                     .thenAcceptBothAsync(completedFuture("Tarantino"),
                             (Void voidA, String stringB) -> {
                                 String val = manager.getActiveContext().getValue() + stringB;
@@ -761,6 +1246,7 @@ public class ContextAwareCompletableFutureTest {
                             contextUnawareThreadpool)
                     .thenAccept(aVoid -> assertThat(manager.getActiveContext().getValue(), is("-QuentinTarantino")))
                     .get();
+            assertThat(manager.getActiveContext().getValue(), is("Pulp Fiction"));
         }
     }
 
@@ -769,6 +1255,15 @@ public class ContextAwareCompletableFutureTest {
         try (Context<String> ctx = manager.initializeNewContext("French Fries")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Ketchup"))
+                    .runAfterBoth(
+                            ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Mayonaise")),
+                            () -> assertThat(manager.getActiveContext().getValue(), is("French Fries")))
+                    .get();
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("French Fries")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Ketchup"), null, null, true)
                     .runAfterBoth(
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Mayonaise")),
                             () -> assertThat(manager.getActiveContext().getValue(), is("Ketchup")))
@@ -783,6 +1278,15 @@ public class ContextAwareCompletableFutureTest {
                     .runAsync(() -> manager.initializeNewContext("Ketchup"))
                     .runAfterBothAsync(
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Mayonaise")),
+                            () -> assertThat(manager.getActiveContext().getValue(), is("French Fries")))
+                    .get();
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("French Fries")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Ketchup"), null, null, true)
+                    .runAfterBothAsync(
+                            ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Mayonaise")),
                             () -> assertThat(manager.getActiveContext().getValue(), is("Ketchup")))
                     .get();
         }
@@ -793,6 +1297,16 @@ public class ContextAwareCompletableFutureTest {
         try (Context<String> ctx = manager.initializeNewContext("French Fries")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Ketchup"))
+                    .runAfterBothAsync(
+                            ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Mayonaise")),
+                            () -> assertThat(manager.getActiveContext().getValue(), is("French Fries")),
+                            contextUnawareThreadpool)
+                    .get();
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("French Fries")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Ketchup"), null, null, true)
                     .runAfterBothAsync(
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Mayonaise")),
                             () -> assertThat(manager.getActiveContext().getValue(), is("Ketchup")),
@@ -807,6 +1321,20 @@ public class ContextAwareCompletableFutureTest {
             ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Ketchup"))
                     .takeNewSnapshot()
+                    .runAfterBoth(
+                            ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Mayonaise")),
+                            () -> {
+                                String val = manager.getActiveContext().getValue();
+                                assertThat(val, is("French Fries"));
+                                manager.initializeNewContext("-" + val);
+                            })
+                    .thenAccept(aVoid -> assertThat(manager.getActiveContext().getValue(), is("-French Fries")))
+                    .get();
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("French Fries")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Ketchup"), null, null, true)
                     .runAfterBoth(
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Mayonaise")),
                             () -> {
@@ -829,6 +1357,20 @@ public class ContextAwareCompletableFutureTest {
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Mayonaise")),
                             () -> {
                                 String val = manager.getActiveContext().getValue();
+                                assertThat(val, is("French Fries"));
+                                manager.initializeNewContext("-" + val);
+                            })
+                    .thenAccept(aVoid -> assertThat(manager.getActiveContext().getValue(), is("-French Fries")))
+                    .get();
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("French Fries")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Ketchup"), null, null, true)
+                    .runAfterBothAsync(
+                            ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Mayonaise")),
+                            () -> {
+                                String val = manager.getActiveContext().getValue();
                                 assertThat(val, is("Ketchup"));
                                 manager.initializeNewContext("-" + val);
                             })
@@ -843,6 +1385,21 @@ public class ContextAwareCompletableFutureTest {
             ContextAwareCompletableFuture
                     .runAsync(() -> manager.initializeNewContext("Ketchup"))
                     .takeNewSnapshot()
+                    .runAfterBothAsync(
+                            ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Mayonaise")),
+                            () -> {
+                                String val = manager.getActiveContext().getValue();
+                                assertThat(val, is("French Fries"));
+                                manager.initializeNewContext("-" + val);
+                            },
+                            contextUnawareThreadpool)
+                    .thenAccept(aVoid -> assertThat(manager.getActiveContext().getValue(), is("-French Fries")))
+                    .get();
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("French Fries")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Ketchup"), null, null, true)
                     .runAfterBothAsync(
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Mayonaise")),
                             () -> {
@@ -864,7 +1421,16 @@ public class ContextAwareCompletableFutureTest {
                     .applyToEither(
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Metric system")),
                             (voidValue) -> manager.getActiveContext().getValue())
-                    .get(), isOneOf("Quarterpounder with Cheese", "Royale with Cheese"));
+                    .get(), is("Quarterpounder with Cheese"));
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Quarterpounder with Cheese")) {
+            assertThat(ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Royale with Cheese"), null, null, true)
+                    .applyToEither(
+                            ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Metric system")),
+                            (voidValue) -> manager.getActiveContext().getValue())
+                    .get(), oneOf("Quarterpounder with Cheese", "Royale with Cheese"));
         }
     }
 
@@ -876,7 +1442,16 @@ public class ContextAwareCompletableFutureTest {
                     .applyToEitherAsync(
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Metric system")),
                             (voidValue) -> manager.getActiveContext().getValue())
-                    .get(), isOneOf("Quarterpounder with Cheese", "Royale with Cheese"));
+                    .get(), is("Quarterpounder with Cheese"));
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Quarterpounder with Cheese")) {
+            assertThat(ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Royale with Cheese"), null, null, true)
+                    .applyToEitherAsync(
+                            ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Metric system")),
+                            (voidValue) -> manager.getActiveContext().getValue())
+                    .get(), oneOf("Quarterpounder with Cheese", "Royale with Cheese"));
         }
     }
 
@@ -889,7 +1464,17 @@ public class ContextAwareCompletableFutureTest {
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Metric system")),
                             voidValue -> manager.getActiveContext().getValue(),
                             contextUnawareThreadpool)
-                    .get(), isOneOf("Quarterpounder with Cheese", "Royale with Cheese"));
+                    .get(), is("Quarterpounder with Cheese"));
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Quarterpounder with Cheese")) {
+            assertThat(ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Royale with Cheese"), null, null, true)
+                    .applyToEitherAsync(
+                            ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Metric system")),
+                            voidValue -> manager.getActiveContext().getValue(),
+                            contextUnawareThreadpool)
+                    .get(), oneOf("Quarterpounder with Cheese", "Royale with Cheese"));
         }
     }
 
@@ -907,7 +1492,21 @@ public class ContextAwareCompletableFutureTest {
                                 return val;
                             })
                     .whenComplete((result, exception) -> assertThat(manager.getActiveContext().getValue(), startsWith("-")))
-                    .get(), isOneOf("Quarterpounder with Cheese", "Royale with Cheese"));
+                    .get(), is("Quarterpounder with Cheese"));
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Quarterpounder with Cheese")) {
+            assertThat(ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Royale with Cheese"), null, null, true)
+                    .applyToEither(
+                            ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Metric system"), null, null, true),
+                            (voidValue) -> {
+                                String val = manager.getActiveContext().getValue();
+                                manager.initializeNewContext("-" + val);
+                                return val;
+                            })
+                    .whenComplete((result, exception) -> assertThat(manager.getActiveContext().getValue(), startsWith("-")))
+                    .get(), oneOf("Quarterpounder with Cheese", "Royale with Cheese"));
         }
     }
 
@@ -925,7 +1524,7 @@ public class ContextAwareCompletableFutureTest {
                                 return val;
                             })
                     .whenComplete((result, exception) -> assertThat(manager.getActiveContext().getValue(), startsWith("-")))
-                    .get(), isOneOf("Quarterpounder with Cheese", "Royale with Cheese"));
+                    .get(), is("Quarterpounder with Cheese"));
         }
     }
 
@@ -944,7 +1543,22 @@ public class ContextAwareCompletableFutureTest {
                             },
                             contextUnawareThreadpool)
                     .whenComplete((result, exception) -> assertThat(manager.getActiveContext().getValue(), startsWith("-")))
-                    .get(), isOneOf("Quarterpounder with Cheese", "Royale with Cheese"));
+                    .get(), is("Quarterpounder with Cheese"));
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Quarterpounder with Cheese")) {
+            assertThat(ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Royale with Cheese"), null, null, true)
+                    .applyToEitherAsync(
+                            ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Metric system"), null, null, true),
+                            (voidValue) -> {
+                                String val = manager.getActiveContext().getValue();
+                                manager.initializeNewContext("-" + val);
+                                return val;
+                            },
+                            contextUnawareThreadpool)
+                    .whenComplete((result, exception) -> assertThat(manager.getActiveContext().getValue(), startsWith("-")))
+                    .get(), oneOf("Quarterpounder with Cheese", "Royale with Cheese"));
         }
     }
 
@@ -956,7 +1570,17 @@ public class ContextAwareCompletableFutureTest {
                     .acceptEither(
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Smoke at home or certain designated places")),
                             voidValue -> assertThat(manager.getActiveContext().getValue(),
-                                    isOneOf("Hash bar", "Hash is legal there")))
+                                    is("Hash bar")))
+                    .get();
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Hash bar")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Hash is legal there"), null, null, true)
+                    .acceptEither(
+                            ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Smoke at home or certain designated places"), null, null, true),
+                            voidValue -> assertThat(manager.getActiveContext().getValue(),
+                                    oneOf("Hash bar", "Hash is legal there")))
                     .get();
         }
     }
@@ -969,7 +1593,7 @@ public class ContextAwareCompletableFutureTest {
                     .acceptEitherAsync(
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Smoke at home or certain designated places")),
                             voidValue -> assertThat(manager.getActiveContext().getValue(),
-                                    isOneOf("Hash bar", "Hash is legal there")))
+                                    is("Hash bar")))
                     .get();
         }
     }
@@ -982,7 +1606,7 @@ public class ContextAwareCompletableFutureTest {
                     .acceptEitherAsync(
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Smoke at home or certain designated places")),
                             voidValue -> assertThat(manager.getActiveContext().getValue(),
-                                    isOneOf("Hash bar", "Hash is legal there")),
+                                    is("Hash bar")),
                             contextUnawareThreadpool)
                     .get();
         }
@@ -998,7 +1622,22 @@ public class ContextAwareCompletableFutureTest {
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Smoke at home or certain designated places")),
                             voidValue -> {
                                 String val = manager.getActiveContext().getValue();
-                                assertThat(val, isOneOf("Hash bar", "Hash is legal there"));
+                                assertThat(val, is("Hash bar"));
+                                manager.initializeNewContext("-" + val);
+                            })
+                    .thenAccept(aVoid -> assertThat(manager.getActiveContext().getValue(), is("-Hash bar")))
+                    .get();
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Hash bar")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Hash is legal there"), null, null, true)
+                    .takeNewSnapshot()
+                    .acceptEither(
+                            ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Smoke at home or certain designated places"), null, null, true),
+                            voidValue -> {
+                                String val = manager.getActiveContext().getValue();
+                                assertThat(val, oneOf("Hash bar", "Hash is legal there"));
                                 manager.initializeNewContext("-" + val);
                             })
                     .thenAccept(aVoid -> assertThat(manager.getActiveContext().getValue(), startsWith("-Hash")))
@@ -1016,7 +1655,22 @@ public class ContextAwareCompletableFutureTest {
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Smoke at home or certain designated places")),
                             voidValue -> {
                                 String val = manager.getActiveContext().getValue();
-                                assertThat(val, isOneOf("Hash bar", "Hash is legal there"));
+                                assertThat(val, is("Hash bar"));
+                                manager.initializeNewContext("-" + val);
+                            })
+                    .thenAccept(aVoid -> assertThat(manager.getActiveContext().getValue(), startsWith("-Hash bar")))
+                    .get();
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Hash bar")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Hash is legal there"), null, null, true)
+                    .takeNewSnapshot()
+                    .acceptEitherAsync(
+                            ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Smoke at home or certain designated places"), null, null, true),
+                            voidValue -> {
+                                String val = manager.getActiveContext().getValue();
+                                assertThat(val, oneOf("Hash bar", "Hash is legal there"));
                                 manager.initializeNewContext("-" + val);
                             })
                     .thenAccept(aVoid -> assertThat(manager.getActiveContext().getValue(), startsWith("-Hash")))
@@ -1034,7 +1688,23 @@ public class ContextAwareCompletableFutureTest {
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Smoke at home or certain designated places")),
                             voidValue -> {
                                 String val = manager.getActiveContext().getValue();
-                                assertThat(val, isOneOf("Hash bar", "Hash is legal there"));
+                                assertThat(val, is("Hash bar"));
+                                manager.initializeNewContext("-" + val);
+                            },
+                            contextUnawareThreadpool)
+                    .thenAccept(aVoid -> assertThat(manager.getActiveContext().getValue(), startsWith("-Hash bar")))
+                    .get();
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Hash bar")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Hash is legal there"), null, null, true)
+                    .takeNewSnapshot()
+                    .acceptEitherAsync(
+                            ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Smoke at home or certain designated places"), null, null, true),
+                            voidValue -> {
+                                String val = manager.getActiveContext().getValue();
+                                assertThat(val, oneOf("Hash bar", "Hash is legal there"));
                                 manager.initializeNewContext("-" + val);
                             },
                             contextUnawareThreadpool)
@@ -1051,7 +1721,7 @@ public class ContextAwareCompletableFutureTest {
                     .runAfterEither(
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Paper cup")),
                             () -> assertThat(manager.getActiveContext().getValue(),
-                                    isOneOf("Movie theater", "Glass of beer")))
+                                    is("Movie theater")))
                     .get();
         }
     }
@@ -1064,7 +1734,7 @@ public class ContextAwareCompletableFutureTest {
                     .runAfterEitherAsync(
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Paper cup")),
                             () -> assertThat(manager.getActiveContext().getValue(),
-                                    isOneOf("Movie theater", "Glass of beer")))
+                                    is("Movie theater")))
                     .get();
         }
     }
@@ -1077,7 +1747,7 @@ public class ContextAwareCompletableFutureTest {
                     .runAfterEitherAsync(
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Paper cup")),
                             () -> assertThat(manager.getActiveContext().getValue(),
-                                    isOneOf("Movie theater", "Glass of beer")),
+                                    is("Movie theater")),
                             contextUnawareThreadpool)
                     .get();
         }
@@ -1093,7 +1763,22 @@ public class ContextAwareCompletableFutureTest {
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Paper cup")),
                             () -> {
                                 String val = manager.getActiveContext().getValue();
-                                assertThat(val, isOneOf("Movie theater", "Glass of beer"));
+                                assertThat(val, is("Movie theater"));
+                                manager.initializeNewContext("-" + val);
+                            })
+                    .thenAccept(aVoid -> assertThat(manager.getActiveContext().getValue(), startsWith("-")))
+                    .get();
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Movie theater")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Glass of beer"), null, null, true)
+                    .takeNewSnapshot()
+                    .runAfterEither(
+                            ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Paper cup"), null, null, true),
+                            () -> {
+                                String val = manager.getActiveContext().getValue();
+                                assertThat(val, oneOf("Movie theater", "Glass of beer"));
                                 manager.initializeNewContext("-" + val);
                             })
                     .thenAccept(aVoid -> assertThat(manager.getActiveContext().getValue(), startsWith("-")))
@@ -1111,7 +1796,22 @@ public class ContextAwareCompletableFutureTest {
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Paper cup")),
                             () -> {
                                 String val = manager.getActiveContext().getValue();
-                                assertThat(val, isOneOf("Movie theater", "Glass of beer"));
+                                assertThat(val, is("Movie theater"));
+                                manager.initializeNewContext("-" + val);
+                            })
+                    .thenAccept(aVoid -> assertThat(manager.getActiveContext().getValue(), is("-Movie theater")))
+                    .get();
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Movie theater")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Glass of beer"), null, null, true)
+                    .takeNewSnapshot()
+                    .runAfterEitherAsync(
+                            ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Paper cup"), null, null, true),
+                            () -> {
+                                String val = manager.getActiveContext().getValue();
+                                assertThat(val, oneOf("Movie theater", "Glass of beer"));
                                 manager.initializeNewContext("-" + val);
                             })
                     .thenAccept(aVoid -> assertThat(manager.getActiveContext().getValue(), startsWith("-")))
@@ -1129,7 +1829,23 @@ public class ContextAwareCompletableFutureTest {
                             ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Paper cup")),
                             () -> {
                                 String val = manager.getActiveContext().getValue();
-                                assertThat(val, isOneOf("Movie theater", "Glass of beer"));
+                                assertThat(val, is("Movie theater"));
+                                manager.initializeNewContext("-" + val);
+                            },
+                            contextUnawareThreadpool)
+                    .thenAccept(aVoid -> assertThat(manager.getActiveContext().getValue(), is("-Movie theater")))
+                    .get();
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("Movie theater")) {
+            ContextAwareCompletableFuture
+                    .runAsync(() -> manager.initializeNewContext("Glass of beer"), null, null, true)
+                    .takeNewSnapshot()
+                    .runAfterEitherAsync(
+                            ContextAwareCompletableFuture.runAsync(() -> manager.initializeNewContext("Paper cup"), null, null, true),
+                            () -> {
+                                String val = manager.getActiveContext().getValue();
+                                assertThat(val, oneOf("Movie theater", "Glass of beer"));
                                 manager.initializeNewContext("-" + val);
                             },
                             contextUnawareThreadpool)
@@ -1150,6 +1866,19 @@ public class ContextAwareCompletableFutureTest {
                             .thenCompose(value -> ContextAwareCompletableFuture.supplyAsync(
                                     () -> value + manager.getActiveContext().getValue()))
                             .get(),
+                    is("JohnJohn"));
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("John")) {
+            assertThat(ContextAwareCompletableFuture
+                            .supplyAsync(() -> {
+                                String current = manager.getActiveContext().getValue();
+                                manager.initializeNewContext("Travolta");
+                                return current;
+                            }, null, null, true)
+                            .thenCompose(value -> ContextAwareCompletableFuture.supplyAsync(
+                                    () -> value + manager.getActiveContext().getValue()))
+                            .get(),
                     is("JohnTravolta"));
         }
     }
@@ -1163,6 +1892,19 @@ public class ContextAwareCompletableFutureTest {
                                 manager.initializeNewContext("Travolta");
                                 return current;
                             })
+                            .thenComposeAsync(value -> ContextAwareCompletableFuture.supplyAsync(
+                                    () -> value + manager.getActiveContext().getValue()))
+                            .get(),
+                    is("JohnJohn"));
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("John")) {
+            assertThat(ContextAwareCompletableFuture
+                            .supplyAsync(() -> {
+                                String current = manager.getActiveContext().getValue();
+                                manager.initializeNewContext("Travolta");
+                                return current;
+                            }, null, null, true)
                             .thenComposeAsync(value -> ContextAwareCompletableFuture.supplyAsync(
                                     () -> value + manager.getActiveContext().getValue()))
                             .get(),
@@ -1183,6 +1925,20 @@ public class ContextAwareCompletableFutureTest {
                                     value -> completedFuture(value + manager.getActiveContext().getValue()),
                                     contextUnawareThreadpool)
                             .get(),
+                    is("JohnJohn"));
+        }
+
+        try (Context<String> ctx = manager.initializeNewContext("John")) {
+            assertThat(ContextAwareCompletableFuture
+                            .supplyAsync(() -> {
+                                String current = manager.getActiveContext().getValue();
+                                manager.initializeNewContext("Travolta");
+                                return current;
+                            }, null, null, true)
+                            .thenComposeAsync(
+                                    value -> completedFuture(value + manager.getActiveContext().getValue()),
+                                    contextUnawareThreadpool)
+                            .get(),
                     is("JohnTravolta"));
         }
     }
@@ -1197,8 +1953,7 @@ public class ContextAwareCompletableFutureTest {
                         DummyContextManager.setCurrentValue("Jules Winnfield");
                         waitFor(latch1);
                         return result;
-                    })
-                    .takeNewSnapshot();
+                    }, null, null, true);
             ContextAwareCompletableFuture<String> future2 = future1.thenApplyAsync(value -> {
                 String result = value + ", " + DummyContextManager.currentValue().orElse("NO VALUE");
                 DummyContextManager.setCurrentValue("Marcellus Wallace");


### PR DESCRIPTION
Relates to #94 where snapshots were taken accidentally after code had run in the forkjoin pool.

This behaviour should be the exception rather than the rule.