### PR TITLE
Deprecate the ContextObservers utility class

### DIFF
--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/ContextManager.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/ContextManager.java
@@ -17,21 +17,23 @@ package nl.talsmasoftware.context;
 
 /**
  * The contract for a ContextManager Service.
+ *
  * <p>
  * Implementations can be registered by providing a fully qualified class name in a service file called:<br>
  * <code>"/META-INF/services/nl.talsmasoftware.context.ContextManager"</code><br>
  * That will take care of any active context being captured in {@link ContextSnapshot} instances
  * managed by the {@link ContextManagers} utility class.<br>
  * <b>Note:</b> <em>Make sure your implementation has a default (no-argument) constructor.</em>
+ *
  * <p>
  * A context manager is required to notify
- * registered {@linkplain nl.talsmasoftware.context.observer.ContextObserver ContextObserver}
- * of context updates.
- * Using the {@linkplain nl.talsmasoftware.context.threadlocal.AbstractThreadLocalContext AbstractThreadLocalContext}
- * already fulfills this requirement.
- * Other implementations can use the utility methods defined in
- * {@linkplain nl.talsmasoftware.context.observer.ContextObservers} to locate the appropriate context observers
- * to be notified.
+ * registered {@linkplain nl.talsmasoftware.context.observer.ContextObserver ContextObserver} instances
+ * of context updates.<br>
+ * The {@linkplain nl.talsmasoftware.context.threadlocal.AbstractThreadLocalContext AbstractThreadLocalContext}
+ * already notifies these observers.<br>
+ * Other implementations can use the {@linkplain ContextManagers#onActivate(Class, Object, Object)}
+ * and {@linkplain ContextManagers#onDeactivate(Class, Object, Object)} methods
+ * to notify the appropriate context observers.
  *
  * @author Sjoerd Talsma
  */

--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/PriorityServiceLoader.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/PriorityServiceLoader.java
@@ -37,7 +37,7 @@ import static java.util.Collections.unmodifiableList;
  * @param <SVC> The type of service to load.
  * @author Sjoerd Talsma
  */
-public final class PriorityServiceLoader<SVC> implements Iterable<SVC> {
+final class PriorityServiceLoader<SVC> implements Iterable<SVC> {
     private static final Logger LOGGER = Logger.getLogger(PriorityServiceLoader.class.getName());
     private static final String SYSTEMPROPERTY_CACHING = "talsmasoftware.context.caching";
     private static final String ENVIRONMENT_CACHING_VALUE = System.getenv(
@@ -48,7 +48,7 @@ public final class PriorityServiceLoader<SVC> implements Iterable<SVC> {
     private final Class<SVC> serviceType;
     private final Map<ClassLoader, List<SVC>> cache = new WeakHashMap<ClassLoader, List<SVC>>();
 
-    public PriorityServiceLoader(Class<SVC> serviceType) {
+    PriorityServiceLoader(Class<SVC> serviceType) {
         if (serviceType == null) throw new NullPointerException("Service type is <null>.");
         this.serviceType = serviceType;
     }
@@ -66,9 +66,9 @@ public final class PriorityServiceLoader<SVC> implements Iterable<SVC> {
     }
 
     /**
-     * Removes the cache so the next call to {@linkplain #iterator()} will attempt to load the objects again.
+     * Remove the cache so the next call to {@linkplain #iterator()} will attempt to load the objects again.
      */
-    public void clearCache() {
+    void clearCache() {
         cache.clear();
     }
 

--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/observer/ContextObserver.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/observer/ContextObserver.java
@@ -19,18 +19,21 @@ import nl.talsmasoftware.context.ContextManager;
 
 /**
  * Observe context updates for a particular class of {@linkplain ContextManager}.
+ *
  * <p>
  * Create your context observer by implementing this interface
  * and registering your class to the {@code ServiceLoader}
  * SPI by adding the fully qualified class name to the resource
  * {@code /META-INF/services/nl.talsmasoftware.context.observer.ContextObserver}.
+ *
  * <p>
  * It is the responsibility of the context implementor to update observers of
  * context updates. SPI lookup of appropriate observers is facilitated
- * by the {@linkplain ContextObservers#onActivate(Class, Object, Object)}
- * and {@linkplain ContextObservers#onDeactivate(Class, Object, Object)}
+ * by the {@linkplain nl.talsmasoftware.context.ContextManagers#onActivate(Class, Object, Object)}
+ * and {@linkplain nl.talsmasoftware.context.ContextManagers#onDeactivate(Class, Object, Object)}
  * utility methods.<br>
- * All subclasses of {@code AbstractThreadLocalContext} are already observable.
+ * All subclasses of {@linkplain nl.talsmasoftware.context.threadlocal.AbstractThreadLocalContext}
+ * are already observable.
  *
  * @author Sjoerd Talsma
  */
@@ -38,13 +41,16 @@ public interface ContextObserver<T> {
 
     /**
      * The observed context manager(s).
+     *
      * <p>
      * Context observers can indicate which type of context manager must be observed using this method.
      * For instance, returning {@code LocaleContextManager.class} here, updates for the {@code LocaleContext} will
      * be offered to this observer.
+     *
      * <p>
      * To observe <em>all</em> context updates, return the {@linkplain ContextManager} interface class itself,
      * since all context managers must implement it.
+     *
      * <p>
      * Return {@code null} to disable the observer.
      *

--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/observer/ContextObservers.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/observer/ContextObservers.java
@@ -16,10 +16,7 @@
 package nl.talsmasoftware.context.observer;
 
 import nl.talsmasoftware.context.ContextManager;
-import nl.talsmasoftware.context.PriorityServiceLoader;
-
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import nl.talsmasoftware.context.ContextManagers;
 
 /**
  * Utility class to assist Context implementors.
@@ -29,14 +26,11 @@ import java.util.logging.Logger;
  * and {@linkplain #onDeactivate(Class, Object, Object) deactivate} occurrances.
  *
  * @author Sjoerd Talsma
+ * @see ContextManagers
+ * @deprecated The (static) utility methods from this class were moved to the {@code ContextManagers} class.
  */
+@Deprecated
 public final class ContextObservers {
-
-    /**
-     * The service loader that loads (and possibly caches) {@linkplain ContextManager} instances in prioritized order.
-     */
-    private static final PriorityServiceLoader<ContextObserver> CONTEXT_OBSERVERS =
-            new PriorityServiceLoader<ContextObserver>(ContextObserver.class);
 
     /**
      * Private constructor to avoid instantiation of this class.
@@ -53,25 +47,14 @@ public final class ContextObservers {
      * @param activatedContextValue The activated context value or {@code null} if no value was activated.
      * @param previousContextValue  The previous context value or {@code null} if unknown or unsupported.
      * @param <T>                   The type managed by the context manager.
+     * @see ContextManagers#onActivate(Class, Object, Object)
+     * @deprecated This method was moved to the {@code ContextManagers} utility class.
      */
-    @SuppressWarnings("unchecked") // If the observer tells us it can observe the values, we trust it.
+    @Deprecated
     public static <T> void onActivate(Class<? extends ContextManager<? super T>> contextManager,
                                       T activatedContextValue,
                                       T previousContextValue) {
-        if (contextManager != null) for (ContextObserver observer : CONTEXT_OBSERVERS) {
-            try {
-                final Class observedContext = observer.getObservedContextManager();
-                if (observedContext != null && observedContext.isAssignableFrom(contextManager)) {
-                    observer.onActivate(activatedContextValue, previousContextValue);
-                }
-            } catch (RuntimeException observationException) {
-                Logger.getLogger(observer.getClass().getName()).log(Level.WARNING,
-                        "Exception in " + observer.getClass().getSimpleName()
-                                + ".onActivate(" + activatedContextValue + ", " + previousContextValue
-                                + ") for " + contextManager.getSimpleName() + ": " + observationException.getMessage(),
-                        observationException);
-            }
-        }
+        ContextManagers.onActivate(contextManager, activatedContextValue, previousContextValue);
     }
 
     /**
@@ -82,25 +65,14 @@ public final class ContextObservers {
      * @param deactivatedContextValue The deactivated context value
      * @param restoredContextValue    The restored context value or {@code null} if unknown or unsupported.
      * @param <T>                     The type managed by the context manager.
+     * @see ContextManagers#onDeactivate(Class, Object, Object)
+     * @deprecated This method was moved to the {@code ContextManagers} utility class.
      */
-    @SuppressWarnings("unchecked") // If the observer tells us it can observe the values, we trust it.
+    @Deprecated
     public static <T> void onDeactivate(Class<? extends ContextManager<? super T>> contextManager,
                                         T deactivatedContextValue,
                                         T restoredContextValue) {
-        if (contextManager != null) for (ContextObserver observer : CONTEXT_OBSERVERS) {
-            try {
-                final Class observedContext = observer.getObservedContextManager();
-                if (observedContext != null && observedContext.isAssignableFrom(contextManager)) {
-                    observer.onDeactivate(deactivatedContextValue, restoredContextValue);
-                }
-            } catch (RuntimeException observationException) {
-                Logger.getLogger(observer.getClass().getName()).log(Level.WARNING,
-                        "Exception in " + observer.getClass().getSimpleName()
-                                + ".onDeactivate(" + deactivatedContextValue + ", " + deactivatedContextValue
-                                + ") for " + contextManager.getSimpleName() + ": " + observationException.getMessage(),
-                        observationException);
-            }
-        }
+        ContextManagers.onDeactivate(contextManager, deactivatedContextValue, restoredContextValue);
     }
 
 }

--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/package-info.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/package-info.java
@@ -13,22 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
- * The core concepts of the context-propagation library.
- * <br>
- * <dl>
- * <dt><a href="Context.html">Context</a>:</dt>
- * <dd>Defines a context as something with a value that can be closed.</dd>
- * <dt><a href="ContextManager.html">ContextManager</a>:</dt>
- * <dd>Interface defining required operations to manage contexts:
- * creating new contexts and obtaining 'current' contexts.</dd>
- * <dt><a href="ContextSnapshot.html">ContextSnapshot</a>:</dt>
- * <dd>A snapshot of one or more active contexts
- * that can be reactivated temporarily (until closed).</dd>
- * <dt><a href="ContextManagers.html">ContextManagers</a>:</dt>
- * <dd>Contains a static method to create a new snapshot
- * from registered ContextManager implementations.</dd>
- * </dl>
+ * Main package defining the core {@code context-propagation} concepts in this library
+ *
+ * <h2><a href="Context.html">Context</a></h2>
+ * <p>
+ * Defines a context as something with a value that can be closed.
+ *
+ * <h2><a href="ContextManager.html">ContextManager</a></h2>
+ * <p>
+ * Interface defining required operations to manage contexts:
+ * creating new contexts and obtaining 'current' contexts.
+ *
+ * <h2><a href="ContextSnapshot.html">ContextSnapshot</a></h2>
+ * <p>
+ * A snapshot of one or more active contexts
+ * that can be reactivated temporarily (until closed).
+ *
+ * <h2><a href="ContextManagers.html">ContextManagers</a></h2>
+ * <p>
+ * Contains a static method to create a new snapshot
+ * from registered ContextManager implementations.
  *
  * @author Sjoerd Talsma
  */

--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/threadlocal/AbstractThreadLocalContext.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/threadlocal/AbstractThreadLocalContext.java
@@ -17,7 +17,7 @@ package nl.talsmasoftware.context.threadlocal;
 
 import nl.talsmasoftware.context.Context;
 import nl.talsmasoftware.context.ContextManager;
-import nl.talsmasoftware.context.observer.ContextObservers;
+import nl.talsmasoftware.context.ContextManagers;
 
 import java.lang.reflect.Modifier;
 import java.util.concurrent.ConcurrentHashMap;
@@ -97,7 +97,7 @@ public abstract class AbstractThreadLocalContext<T> implements Context<T> {
         this.value = newValue;
         this.sharedThreadLocalContext.set(this);
         logger.log(Level.FINEST, "Initialized new {0}.", this);
-        ContextObservers.onActivate(contextManagerType, value, parentContext == null ? null : parentContext.getValue());
+        ContextManagers.onActivate(contextManagerType, value, parentContext == null ? null : parentContext.getValue());
     }
 
     /**
@@ -149,7 +149,7 @@ public abstract class AbstractThreadLocalContext<T> implements Context<T> {
         final Context<T> restored = this.unwindIfNecessary(); // Remove this context created in the same thread.
         logger.log(Level.FINEST, "Closed {0}.", this);
         if (observe) {
-            ContextObservers.onDeactivate(contextManagerType, this.value, restored == null ? null : restored.getValue());
+            ContextManagers.onDeactivate(contextManagerType, this.value, restored == null ? null : restored.getValue());
         }
     }
 

--- a/context-propagation-java5/src/test/java/nl/talsmasoftware/context/NoContextManagersTest.java
+++ b/context-propagation-java5/src/test/java/nl/talsmasoftware/context/NoContextManagersTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016-2019 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.context;
+
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class NoContextManagersTest {
+    private static final String SERVICE_LOCATION = "target/test-classes/META-INF/services/";
+    private static final File SERVICE_FILE = new File(SERVICE_LOCATION + ContextManager.class.getName());
+    private static final File TMP_SERVICE_FILE = new File(SERVICE_LOCATION + "tmp-ContextManager");
+
+    @Test
+    public void testReactivate_withoutContextManagers() {
+        Context<String> ctx1 = new DummyContext("foo");
+        ContextSnapshot snapshot = ContextManagers.createContextSnapshot();
+        ctx1.close();
+
+        assertThat("Move service file", SERVICE_FILE.renameTo(TMP_SERVICE_FILE), is(true));
+        try {
+
+            Context<Void> reactivated = snapshot.reactivate();
+
+            reactivated.close();
+
+        } finally {
+            assertThat("Restore service file!", TMP_SERVICE_FILE.renameTo(SERVICE_FILE), is(true));
+        }
+    }
+
+    @Test
+    public void testCreateSnapshot_withoutContextManagers() {
+        assertThat("Move service file", SERVICE_FILE.renameTo(TMP_SERVICE_FILE), is(true));
+        try {
+
+            ContextSnapshot snapshot = ContextManagers.createContextSnapshot();
+            assertThat(snapshot, is(notNullValue()));
+
+            Context<Void> reactivated = snapshot.reactivate();
+            assertThat(reactivated, is(notNullValue()));
+            reactivated.close();
+
+        } finally {
+            assertThat("Restore service file!", TMP_SERVICE_FILE.renameTo(SERVICE_FILE), is(true));
+        }
+    }
+
+    @Test
+    public void testClearManagedContexts_withoutContextManagers() {
+        assertThat("Move service file", SERVICE_FILE.renameTo(TMP_SERVICE_FILE), is(true));
+        try {
+            ContextManagers.clearActiveContexts();
+            // there should be no exception
+        } finally {
+            assertThat("Restore service file!", TMP_SERVICE_FILE.renameTo(SERVICE_FILE), is(true));
+        }
+    }
+
+}

--- a/context-propagation-java5/src/test/java/nl/talsmasoftware/context/observer/ContextObserversTest.java
+++ b/context-propagation-java5/src/test/java/nl/talsmasoftware/context/observer/ContextObserversTest.java
@@ -41,6 +41,10 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.fail;
 
+/**
+ * @deprecated To test a deprecated class with less warnings, we deprecate the test as well
+ */
+@Deprecated
 public class ContextObserversTest {
 
     @Before

--- a/context-propagation-java5/src/test/java/nl/talsmasoftware/context/observer/Observed.java
+++ b/context-propagation-java5/src/test/java/nl/talsmasoftware/context/observer/Observed.java
@@ -21,9 +21,9 @@ import org.hamcrest.Matcher;
 
 import java.util.Arrays;
 
-final class Observed {
+public final class Observed {
 
-    enum Action {
+    public enum Action {
         ACTIVATE, DEACTIVATE
     }
 

--- a/context-propagation-java5/src/test/java/nl/talsmasoftware/context/observer/SimpleContextObserver.java
+++ b/context-propagation-java5/src/test/java/nl/talsmasoftware/context/observer/SimpleContextObserver.java
@@ -21,9 +21,9 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 public class SimpleContextObserver implements ContextObserver<Object> {
-    static Class<? extends ContextManager> observedContextManager = null;
+    public static Class<? extends ContextManager> observedContextManager = null;
 
-    static final List<Observed> observed = new CopyOnWriteArrayList<Observed>();
+    public static final List<Observed> observed = new CopyOnWriteArrayList<Observed>();
 
     @SuppressWarnings("unchecked")
     public Class<? extends ContextManager<Object>> getObservedContextManager() {

--- a/mdc-propagation/src/main/java/nl/talsmasoftware/context/mdc/MdcManager.java
+++ b/mdc-propagation/src/main/java/nl/talsmasoftware/context/mdc/MdcManager.java
@@ -17,8 +17,8 @@ package nl.talsmasoftware.context.mdc;
 
 import nl.talsmasoftware.context.Context;
 import nl.talsmasoftware.context.ContextManager;
+import nl.talsmasoftware.context.ContextManagers;
 import nl.talsmasoftware.context.clearable.Clearable;
-import nl.talsmasoftware.context.observer.ContextObservers;
 import org.slf4j.MDC;
 
 import java.util.Map;
@@ -88,7 +88,7 @@ public class MdcManager implements ContextManager<Map<String, String>> {
             this.previous = previous;
             this.value = value;
             this.closed = new AtomicBoolean(closed);
-            ContextObservers.onActivate(MdcManager.class, value, previous);
+            ContextManagers.onActivate(MdcManager.class, value, previous);
         }
 
         public Map<String, String> getValue() {
@@ -99,7 +99,7 @@ public class MdcManager implements ContextManager<Map<String, String>> {
             if (closed.compareAndSet(false, true)) {
                 if (previous == null) MDC.clear();
                 else MDC.setContextMap(previous);
-                ContextObservers.onDeactivate(MdcManager.class, value, previous);
+                ContextManagers.onDeactivate(MdcManager.class, value, previous);
             }
         }
 

--- a/opentracing-span-propagation/src/main/java/nl/talsmasoftware/context/opentracing/SpanManager.java
+++ b/opentracing-span-propagation/src/main/java/nl/talsmasoftware/context/opentracing/SpanManager.java
@@ -21,7 +21,7 @@ import io.opentracing.Span;
 import io.opentracing.util.GlobalTracer;
 import nl.talsmasoftware.context.Context;
 import nl.talsmasoftware.context.ContextManager;
-import nl.talsmasoftware.context.observer.ContextObservers;
+import nl.talsmasoftware.context.ContextManagers;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -89,7 +89,7 @@ public class SpanManager implements ContextManager<Span> {
         private SpanContext(Span span, Scope scope) {
             this.span = span;
             this.scope = scope;
-            ContextObservers.onActivate(SpanManager.class, span, null);
+            ContextManagers.onActivate(SpanManager.class, span, null);
         }
 
         @Override
@@ -103,7 +103,7 @@ public class SpanManager implements ContextManager<Span> {
                 if (scope != null) {
                     scope.close();
                 }
-                ContextObservers.onDeactivate(SpanManager.class, span, null);
+                ContextManagers.onDeactivate(SpanManager.class, span, null);
             }
         }
 

--- a/servletrequest-propagation/src/main/java/nl/talsmasoftware/context/servletrequest/ServletRequestContext.java
+++ b/servletrequest-propagation/src/main/java/nl/talsmasoftware/context/servletrequest/ServletRequestContext.java
@@ -16,7 +16,7 @@
 package nl.talsmasoftware.context.servletrequest;
 
 import nl.talsmasoftware.context.Context;
-import nl.talsmasoftware.context.observer.ContextObservers;
+import nl.talsmasoftware.context.ContextManagers;
 
 import javax.servlet.ServletRequest;
 
@@ -34,7 +34,7 @@ final class ServletRequestContext implements Context<ServletRequest> {
     ServletRequestContext(ServletRequest servletRequest) {
         this.servletRequest = servletRequest;
         CONTEXT.set(this);
-        ContextObservers.onActivate(ServletRequestContextManager.class, servletRequest, null);
+        ContextManagers.onActivate(ServletRequestContextManager.class, servletRequest, null);
     }
 
     static Context<ServletRequest> current() {
@@ -49,7 +49,7 @@ final class ServletRequestContext implements Context<ServletRequest> {
         final ServletRequest deactivated = servletRequest;
         servletRequest = null;
         CONTEXT.set(null);
-        ContextObservers.onDeactivate(ServletRequestContextManager.class, deactivated, null);
+        ContextManagers.onDeactivate(ServletRequestContextManager.class, deactivated, null);
     }
 
     @Override

--- a/spring-security-context/src/main/java/nl/talsmasoftware/context/springsecurity/SpringSecurityContextManager.java
+++ b/spring-security-context/src/main/java/nl/talsmasoftware/context/springsecurity/SpringSecurityContextManager.java
@@ -16,8 +16,8 @@
 package nl.talsmasoftware.context.springsecurity;
 
 import nl.talsmasoftware.context.Context;
+import nl.talsmasoftware.context.ContextManagers;
 import nl.talsmasoftware.context.clearable.ClearableContextManager;
-import nl.talsmasoftware.context.observer.ContextObservers;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -76,7 +76,7 @@ public class SpringSecurityContextManager implements ClearableContextManager<Aut
             this.current = current;
             this.previous = previous;
             this.closed = new AtomicBoolean(alreadyClosed);
-            ContextObservers.onActivate(SpringSecurityContextManager.class, auth(current), auth(previous));
+            ContextManagers.onActivate(SpringSecurityContextManager.class, auth(current), auth(previous));
         }
 
         public Authentication getValue() {
@@ -86,7 +86,7 @@ public class SpringSecurityContextManager implements ClearableContextManager<Aut
         public void close() {
             if (closed.compareAndSet(false, true)) {
                 SecurityContextHolder.setContext(previous);
-                ContextObservers.onDeactivate(SpringSecurityContextManager.class, auth(current), auth(previous));
+                ContextManagers.onDeactivate(SpringSecurityContextManager.class, auth(current), auth(previous));
             }
         }
 


### PR DESCRIPTION
Methods are moved to the existing ContextManagers class.