### PR TITLE
Rename `Timing` utility class to `Timers` avoiding package name clash

### DIFF
--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/ContextManagers.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/ContextManagers.java
@@ -83,14 +83,14 @@ public final class ContextManagers {
                     if (LOGGER.isLoggable(Level.FINEST)) {
                         LOGGER.finest("Active context of " + manager + " added to new snapshot: " + activeContext + ".");
                     }
-                    Timing.timed(System.nanoTime() - managerStart, manager.getClass(), "getActiveContext");
+                    Timers.timed(System.nanoTime() - managerStart, manager.getClass(), "getActiveContext");
                 } else if (LOGGER.isLoggable(Level.FINEST)) {
                     LOGGER.log(Level.FINEST, "There is no active context for " + manager + " in this snapshot.");
                 }
             } catch (RuntimeException rte) {
                 CONTEXT_MANAGERS.clearCache();
                 LOGGER.log(Level.WARNING, "Exception obtaining active context from " + manager + " for snapshot.", rte);
-                Timing.timed(System.nanoTime() - managerStart, manager.getClass(), "getActiveContext.exception");
+                Timers.timed(System.nanoTime() - managerStart, manager.getClass(), "getActiveContext.exception");
             }
         }
         if (managerStart == null) {
@@ -98,7 +98,7 @@ public final class ContextManagers {
             LOGGER.log(Level.INFO, noContextManagersFound.getMessage(), noContextManagersFound);
         }
         ContextSnapshot result = new ContextSnapshotImpl(managers, values);
-        Timing.timed(System.nanoTime() - start, ContextManagers.class, "createContextSnapshot");
+        Timers.timed(System.nanoTime() - start, ContextManagers.class, "createContextSnapshot");
         return result;
     }
 
@@ -131,7 +131,7 @@ public final class ContextManagers {
                     if (LOGGER.isLoggable(Level.FINEST)) {
                         LOGGER.finest("Active context of " + manager + " was cleared.");
                     }
-                    Timing.timed(System.nanoTime() - managerStart, manager.getClass(), "clear");
+                    Timers.timed(System.nanoTime() - managerStart, manager.getClass(), "clear");
                 } else {
                     Context activeContext = manager.getActiveContext();
                     if (activeContext != null) {
@@ -142,14 +142,14 @@ public final class ContextManagers {
                 }
             } catch (RuntimeException rte) {
                 LOGGER.log(Level.WARNING, "Exception clearing active context from " + manager + ".", rte);
-                Timing.timed(System.nanoTime() - managerStart, manager.getClass(), "clear.exception");
+                Timers.timed(System.nanoTime() - managerStart, manager.getClass(), "clear.exception");
             }
         }
         if (managerStart == null) {
             NoContextManagersFound noContextManagersFound = new NoContextManagersFound();
             LOGGER.log(Level.INFO, noContextManagersFound.getMessage(), noContextManagersFound);
         }
-        Timing.timed(System.nanoTime() - start, ContextManagers.class, "clearActiveContexts");
+        Timers.timed(System.nanoTime() - start, ContextManagers.class, "clearActiveContexts");
     }
 
     /**
@@ -263,7 +263,7 @@ public final class ContextManagers {
                                 "and has not implemented the Clearable interface?");
             }
         }
-        Timing.timed(System.nanoTime() - start, contextType, "clear");
+        Timers.timed(System.nanoTime() - start, contextType, "clear");
     }
 
     /**
@@ -288,7 +288,7 @@ public final class ContextManagers {
                     reactivatedContexts.add(reactivate(managers[i], values[i]));
                 }
                 ReactivatedContext reactivatedContext = new ReactivatedContext(reactivatedContexts);
-                Timing.timed(System.nanoTime() - start, ContextSnapshot.class, "reactivate");
+                Timers.timed(System.nanoTime() - start, ContextSnapshot.class, "reactivate");
                 return reactivatedContext;
             } catch (RuntimeException reactivationException) {
                 CONTEXT_MANAGERS.clearCache();
@@ -314,7 +314,7 @@ public final class ContextManagers {
             if (LOGGER.isLoggable(Level.FINEST)) {
                 LOGGER.finest("Context reactivated from snapshot by " + contextManager + ": " + reactivated + ".");
             }
-            Timing.timed(System.nanoTime() - start, contextManager.getClass(), "initializeNewContext");
+            Timers.timed(System.nanoTime() - start, contextManager.getClass(), "initializeNewContext");
             return reactivated;
         }
 

--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/Timers.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/Timers.java
@@ -28,8 +28,8 @@ import java.util.logging.Logger;
  *
  * @author Sjoerd Talsma
  */
-final class Timing {
-    private static final Logger LOGGER = Logger.getLogger(Timing.class.getName());
+final class Timers {
+    private static final Logger TIMING_LOGGER = Logger.getLogger("nl.talsmasoftware.context.Timing");
 
     /**
      * Singleton containing resolved ContextTimer delegates.
@@ -51,8 +51,8 @@ final class Timing {
         for (ContextTimer delegate : Singleton.INSTANCE.delegates) {
             delegate.update(type, method, durationNanos, TimeUnit.NANOSECONDS);
         }
-        if (LOGGER.isLoggable(Level.FINEST)) {
-            LOGGER.log(Level.FINEST, "{0}.{1}: {2,number}ns", new Object[]{type.getName(), method, durationNanos});
+        if (TIMING_LOGGER.isLoggable(Level.FINEST)) {
+            TIMING_LOGGER.log(Level.FINEST, "{0}.{1}: {2,number}ns", new Object[]{type.getName(), method, durationNanos});
         }
     }
 

--- a/context-propagation-java5/src/test/java/nl/talsmasoftware/context/TimersTest.java
+++ b/context-propagation-java5/src/test/java/nl/talsmasoftware/context/TimersTest.java
@@ -26,15 +26,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 /**
- * Test for the package-protected Timing utility class.
+ * Test for the package-protected Timers utility class.
  *
  * @author Sjoerd Talsma
  */
-public class TimingTest {
+public class TimersTest {
 
     @Test
     public void testTimingDelegation() {
-        Timing.timed(TimeUnit.MILLISECONDS.toNanos(150), getClass(), "testTimingDelegation");
+        Timers.timed(TimeUnit.MILLISECONDS.toNanos(150), getClass(), "testTimingDelegation");
         assertThat(TestContextTimer.getLastTimedMillis(getClass(), "testTimingDelegation"), is(150L));
     }
 

--- a/context-propagation-java5/src/test/resources/META-INF/services/nl.talsmasoftware.context.timing.ContextTimer
+++ b/context-propagation-java5/src/test/resources/META-INF/services/nl.talsmasoftware.context.timing.ContextTimer
@@ -1,1 +1,1 @@
-nl.talsmasoftware.context.TimingTest$TestContextTimer
+nl.talsmasoftware.context.TimersTest$TestContextTimer


### PR DESCRIPTION
This avoids a possible nameclash that surfaced in light of another javadoc issue with openjvm 11.0.2 in combination with maven-javadoc-plugin 3.1.0: [MJAVADOC-583](https://issues.apache.org/jira/browse/MJAVADOC-583).

Renaming the package-private utility class is a safe action to take regardless, and may avoid further possible name clashes (especially on case-insensitive file systems this may be problematic in other cases)

The name of the logger to be configured to show timing has been kept unchanged at `"nl.talsmasoftware.context.Timing"`