### PR TITLE
close reactivated contexts in reverse order

### DIFF
--- a/context-propagation-java5/src/main/java/nl/talsmasoftware/context/ContextManagers.java
+++ b/context-propagation-java5/src/main/java/nl/talsmasoftware/context/ContextManagers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 Talsma ICT
+ * Copyright 2016-2021 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -342,7 +342,9 @@ public final class ContextManagers {
 
         public void close() {
             RuntimeException closeException = null;
-            for (Context<?> reactivated : this.reactivated) {
+            // close in reverse order of reactivation
+            for (int i = this.reactivated.size() - 1; i >= 0; i--) {
+                Context<?> reactivated = this.reactivated.get(i);
                 if (reactivated != null) try {
                     reactivated.close();
                 } catch (RuntimeException rte) {


### PR DESCRIPTION
This issue came up when adding a ContextManager for io.grpc.Context, which interacted with the SpanContextManager which also uses io.grpc.Context.
For interdependent contexts, the contexts should be closed in the reverse order in which they were activated. This change makes that happen.
