### PR TITLE
Rename module `mdc-propagation` to `slf4j-propagation`

### DIFF
--- a/mdc-propagation/src/main/resources/META-INF/services/nl.talsmasoftware.context.ContextManager
+++ b/mdc-propagation/src/main/resources/META-INF/services/nl.talsmasoftware.context.ContextManager
@@ -1,1 +1,0 @@
-nl.talsmasoftware.context.mdc.MdcManager

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
         <module>context-propagation-metrics</module>
         <module>context-propagation-micrometer</module>
         <module>locale-context</module>
-        <module>mdc-propagation</module>
         <module>servletrequest-propagation</module>
+        <module>slf4j-propagation</module>
         <module>spring-security-context</module>
         <module>opentracing-span-propagation</module>
         <module>relocation</module>

--- a/readme.md
+++ b/readme.md
@@ -162,7 +162,7 @@ configure various timers in the default metric registry of your application.
 
 
   [servletrequest propagation]: servletrequest-propagation
-  [mdc propagation]: mdc-propagation
+  [mdc propagation]: slf4j-propagation
   [locale context]: locale-context
   [spring security context]: spring-security-context
   [opentracing span propagation]: opentracing-span-propagation

--- a/relocation/mdc/pom.xml
+++ b/relocation/mdc/pom.xml
@@ -22,26 +22,24 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>nl.talsmasoftware.context</groupId>
-        <artifactId>context-propagation-root</artifactId>
+        <artifactId>context-propagation-relocation</artifactId>
         <version>1.0.9-SNAPSHOT</version>
     </parent>
 
     <!-- Artifact identification -->
-    <artifactId>context-propagation-relocation</artifactId>
+    <artifactId>mdc-propagation</artifactId>
     <packaging>pom</packaging>
 
     <!-- Project information -->
-    <name>Relocation</name>
-
-    <modules>
-        <module>old-root</module>
-        <module>java5</module>
-        <module>java8</module>
-        <module>mdc</module>
-    </modules>
+    <name>Relocation (mdc)</name>
 
     <properties>
-        <root.basedir>${project.parent.basedir}</root.basedir>
+        <root.basedir>${project.parent.basedir}/..</root.basedir>
     </properties>
 
+    <distributionManagement>
+        <relocation>
+            <artifactId>slf4j-propagation</artifactId>
+        </relocation>
+    </distributionManagement>
 </project>

--- a/slf4j-propagation/README.md
+++ b/slf4j-propagation/README.md
@@ -2,7 +2,7 @@
 
 # Slf4J MDC propagation library
 
-Adding the `mdc-propagation` jar to your classpath
+Adding the `slf4j-propagation` jar to your classpath
 is all that is needed to let the [Mapped Diagnostic Context (MDC)][MDC] 
 from the [Simple Logging Facade for Java (SLF4J)][Slf4J] 
 be automatically included into the `ContextSnapshot`.
@@ -13,7 +13,7 @@ Add it to your classpath.
 ```xml
 <dependency>
     <groupId>nl.talsmasoftware.context</groupId>
-    <artifactId>mdc-propagation</artifactId>
+    <artifactId>slf4j-propagation</artifactId>
     <version>[see Maven badge above]</version>
 </dependency>
 ```
@@ -27,8 +27,8 @@ The `ContextAwareExecutorService` automatically propagates the full [MDC] conten
 into all executed tasks this way.
 
 
-  [maven-img]: https://img.shields.io/maven-central/v/nl.talsmasoftware.context/mdc-propagation
-  [maven]: https://search.maven.org/artifact/nl.talsmasoftware.context/mdc-propagation
+  [maven-img]: https://img.shields.io/maven-central/v/nl.talsmasoftware.context/slf4j-propagation
+  [maven]: https://search.maven.org/artifact/nl.talsmasoftware.context/slf4j-propagation
 
   [slf4j]: https://www.slf4j.org/
   [mdc]: https://www.slf4j.org/api/org/slf4j/MDC.html

--- a/slf4j-propagation/pom.xml
+++ b/slf4j-propagation/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2019 Talsma ICT
+    Copyright 2016-2021 Talsma ICT
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@
     </parent>
 
     <!-- Artifact identification -->
-    <artifactId>mdc-propagation</artifactId>
-    <name>Propagation of MDC</name>
+    <artifactId>slf4j-propagation</artifactId>
+    <name>Propagation of SLF4J MDC</name>
     <packaging>jar</packaging>
 
     <properties>

--- a/slf4j-propagation/src/main/java/nl/talsmasoftware/context/mdc/MdcManager.java
+++ b/slf4j-propagation/src/main/java/nl/talsmasoftware/context/mdc/MdcManager.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016-2021 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.context.mdc;
+
+import nl.talsmasoftware.context.slf4j.mdc.Slf4jMdcManager;
+
+/**
+ * {@inheritDoc}
+ *
+ * @deprecated This class moved to package {@code nl.talsmasoftware.context.slf4j.mdc}.
+ */
+@Deprecated
+public class MdcManager extends Slf4jMdcManager {
+}

--- a/slf4j-propagation/src/main/java/nl/talsmasoftware/context/mdc/package-info.java
+++ b/slf4j-propagation/src/main/java/nl/talsmasoftware/context/mdc/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 Talsma ICT
+ * Copyright 2016-2021 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
- * Propagate the {@link org.slf4j.MDC Slf4J MDC} content from one thread to another.
- *
- * <p>
- * This context manager maintains no threadlocal state of its own,
- * instead it propagates the
- * existing {@linkplain org.slf4j.MDC#getCopyOfContextMap() MDC context map}
- * into each {@linkplain nl.talsmasoftware.context.ContextSnapshot context snapshot}
- * to be applied again when the snapshot
- * is {@linkplain nl.talsmasoftware.context.ContextSnapshot#reactivate() reactivated}
- * in another thread.
+ * @deprecated This package was renamed to {@code nl.talsmasoftware.context.slf4j.mdc}
  */
 package nl.talsmasoftware.context.mdc;

--- a/slf4j-propagation/src/main/java/nl/talsmasoftware/context/slf4j/mdc/Slf4jMdcManager.java
+++ b/slf4j-propagation/src/main/java/nl/talsmasoftware/context/slf4j/mdc/Slf4jMdcManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 Talsma ICT
+ * Copyright 2016-2021 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.talsmasoftware.context.mdc;
+package nl.talsmasoftware.context.slf4j.mdc;
 
 import nl.talsmasoftware.context.Context;
 import nl.talsmasoftware.context.ContextManager;
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * @author Sjoerd Talsma
  */
-public class MdcManager implements ContextManager<Map<String, String>> {
+public class Slf4jMdcManager implements ContextManager<Map<String, String>> {
 
     /**
      * Initializes a new MDC context populated by the specified values.
@@ -59,7 +59,7 @@ public class MdcManager implements ContextManager<Map<String, String>> {
         final Map<String, String> previous = MDC.getCopyOfContextMap();
         if (mdcValues == null) MDC.clear();
         else MDC.setContextMap(mdcValues);
-        return new MdcContext(previous, mdcValues, false);
+        return new Slf4jMdcContext(previous, mdcValues, false);
     }
 
     /**
@@ -72,7 +72,7 @@ public class MdcManager implements ContextManager<Map<String, String>> {
      */
     public Context<Map<String, String>> getActiveContext() {
         // Return fresh context that is 'already-closed'. Therefore it doesn't need a previous mdc.
-        return new MdcContext(null, MDC.getCopyOfContextMap(), true);
+        return new Slf4jMdcContext(null, MDC.getCopyOfContextMap(), true);
     }
 
     @Override
@@ -80,15 +80,15 @@ public class MdcManager implements ContextManager<Map<String, String>> {
         return getClass().getSimpleName();
     }
 
-    private static final class MdcContext implements Context<Map<String, String>>, Clearable {
+    private static final class Slf4jMdcContext implements Context<Map<String, String>>, Clearable {
         private final Map<String, String> previous, value;
         private final AtomicBoolean closed;
 
-        private MdcContext(Map<String, String> previous, Map<String, String> value, boolean closed) {
+        private Slf4jMdcContext(Map<String, String> previous, Map<String, String> value, boolean closed) {
             this.previous = previous;
             this.value = value;
             this.closed = new AtomicBoolean(closed);
-            ContextManagers.onActivate(MdcManager.class, value, previous);
+            ContextManagers.onActivate(Slf4jMdcManager.class, value, previous);
         }
 
         public Map<String, String> getValue() {
@@ -99,7 +99,7 @@ public class MdcManager implements ContextManager<Map<String, String>> {
             if (closed.compareAndSet(false, true)) {
                 if (previous == null) MDC.clear();
                 else MDC.setContextMap(previous);
-                ContextManagers.onDeactivate(MdcManager.class, value, previous);
+                ContextManagers.onDeactivate(Slf4jMdcManager.class, value, previous);
             }
         }
 
@@ -109,7 +109,7 @@ public class MdcManager implements ContextManager<Map<String, String>> {
 
         @Override
         public String toString() {
-            return closed.get() ? "MdcContext{closed}" : "MdcContext" + (value == null ? "{}" : value);
+            return closed.get() ? "Slf4jMdcContext{closed}" : "Slf4jMdcContext" + (value == null ? "{}" : value);
         }
 
     }

--- a/slf4j-propagation/src/main/java/nl/talsmasoftware/context/slf4j/mdc/package-info.java
+++ b/slf4j-propagation/src/main/java/nl/talsmasoftware/context/slf4j/mdc/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016-2021 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Propagate the {@link org.slf4j.MDC Slf4J MDC} content from one thread to another.
+ *
+ * <p>
+ * This context manager maintains no threadlocal state of its own,
+ * instead it propagates the
+ * existing {@linkplain org.slf4j.MDC#getCopyOfContextMap() MDC context map}
+ * into each {@linkplain nl.talsmasoftware.context.ContextSnapshot context snapshot}
+ * to be applied again when the snapshot
+ * is {@linkplain nl.talsmasoftware.context.ContextSnapshot#reactivate() reactivated}
+ * in another thread.
+ */
+package nl.talsmasoftware.context.slf4j.mdc;

--- a/slf4j-propagation/src/main/resources/META-INF/services/nl.talsmasoftware.context.ContextManager
+++ b/slf4j-propagation/src/main/resources/META-INF/services/nl.talsmasoftware.context.ContextManager
@@ -1,0 +1,1 @@
+nl.talsmasoftware.context.slf4j.mdc.Slf4jMdcManager

--- a/slf4j-propagation/src/test/java/nl/talsmasoftware/context/slf4j/mdc/Slf4jMdcManagerTest.java
+++ b/slf4j-propagation/src/test/java/nl/talsmasoftware/context/slf4j/mdc/Slf4jMdcManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 Talsma ICT
+ * Copyright 2016-2021 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.talsmasoftware.context.mdc;
+package nl.talsmasoftware.context.slf4j.mdc;
 
 import nl.talsmasoftware.context.Context;
 import nl.talsmasoftware.context.ContextManagers;
@@ -36,11 +36,11 @@ import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.is;
 
 /**
- * Unit test for the {@link MdcManager}.
+ * Unit test for the {@link Slf4jMdcManager}.
  *
  * @author Sjoerd Talsma
  */
-public class MdcManagerTest {
+public class Slf4jMdcManagerTest {
 
     ExecutorService threadpool;
 
@@ -92,19 +92,19 @@ public class MdcManagerTest {
     }
 
     @Test
-    public void testMdcManagerToString() {
-        assertThat(new MdcManager(), hasToString("MdcManager"));
+    public void testSlf4jMdcManagerToString() {
+        assertThat(new Slf4jMdcManager(), hasToString("Slf4jMdcManager"));
     }
 
     @Test
-    public void testMdcContextToString() {
-        MdcManager mgr = new MdcManager();
+    public void testSlf4jMdcContextToString() {
+        Slf4jMdcManager mgr = new Slf4jMdcManager();
         MDC.put("dummy", "value");
         Map<String, String> mdc = MDC.getCopyOfContextMap();
-        assertThat(mgr.getActiveContext(), hasToString("MdcContext{closed}"));
+        assertThat(mgr.getActiveContext(), hasToString("Slf4jMdcContext{closed}"));
         Context<Map<String, String>> ctx = mgr.initializeNewContext(mdc);
         try {
-            assertThat(ctx, hasToString("MdcContext" + mdc));
+            assertThat(ctx, hasToString("Slf4jMdcContext" + mdc));
         } finally {
             ctx.close();
         }
@@ -112,7 +112,7 @@ public class MdcManagerTest {
 
     @Test
     public void testClearActiveContexts() {
-        MdcManager mgr = new MdcManager();
+        Slf4jMdcManager mgr = new Slf4jMdcManager();
         MDC.put("dummy", "value");
         // Test no-op for MdcManager
         ContextManagers.clearActiveContexts();


### PR DESCRIPTION
This pull request implements proposed change of `mdc-propagation` module to `slf4j-propagation` in a backwards-compatible way.

This will allow #207 to be reduced in scope

Fixes #209