### PR TITLE
Repair bill-of-materials dependency-management inheritance. 

### DIFF
--- a/context-propagation-bom/pom.xml
+++ b/context-propagation-bom/pom.xml
@@ -231,6 +231,13 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/context-propagation-bom/pom.xml
+++ b/context-propagation-bom/pom.xml
@@ -19,24 +19,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>nl.talsmasoftware.context</groupId>
-        <artifactId>context-propagation-root</artifactId>
-        <version>1.0.10-SNAPSHOT</version>
-    </parent>
 
+    <groupId>nl.talsmasoftware.context</groupId>
     <artifactId>context-propagation-bom</artifactId>
+    <version>1.0.10-SNAPSHOT</version>
     <packaging>pom</packaging>
+
     <name>Context propagation (bill-of-materials)</name>
     <description>
         Bill of Materials with exported module versions.
         This only contains 'opinionated' versions
         so modules of this library and crucial transitive jars.
     </description>
-
-    <properties>
-        <root.basedir>${project.parent.basedir}</root.basedir>
-    </properties>
 
     <dependencyManagement>
         <dependencies>
@@ -227,15 +221,5 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
-    <dependencies>
-        <dependency> <!-- Declare UML doclet version as provided dependency in the BOM to get dependabot notifications -->
-            <groupId>nl.talsmasoftware</groupId>
-            <artifactId>umldoclet</artifactId>
-            <version>${umldoclet.version}</version>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-    </dependencies>
 
 </project>

--- a/context-propagation-bom/pom.xml
+++ b/context-propagation-bom/pom.xml
@@ -222,4 +222,15 @@
         </dependencies>
     </dependencyManagement>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -332,16 +332,6 @@
         </plugins>
     </build>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- Test dependencies for all modules: -->
         <dependency>
@@ -373,6 +363,14 @@
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency> <!-- Declare UML doclet version as provided dependency to get dependabot notifications -->
+            <groupId>nl.talsmasoftware</groupId>
+            <artifactId>umldoclet</artifactId>
+            <version>${umldoclet.version}</version>
+            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- No longer inherit dependencyManagement from context-propagation-root.
- No longer declare slf4j version in dependencyManagement as it was declared explicitly anyway.
- Move umldoclet dependency declaration out of bill-of-materials where it didn't belong.
- Skip jacoco step in bill-of-materials module.
- Skip coveralls step in bill-of-materials module.

This fixes #269