### PR TITLE
Update GitHub actions & enable Dependabot for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,12 @@ updates:
   - sjoerdtalsma
   assignees:
   - sjoerdtalsma
+
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: monthly
+  reviewers:
+  - sjoerdtalsma
+  assignees:
+  - sjoerdtalsma

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup GPG
@@ -40,7 +40,7 @@ jobs:
           distribution: 'zulu'
           java-version: 21
       - name: Setup maven cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-m2-repo-${{ hashFiles('**/pom.xml') }}
@@ -72,7 +72,7 @@ jobs:
     steps:
       - name: Check out code
         if: env.GH_TOKEN != null
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ env.GH_TOKEN }}
@@ -89,7 +89,7 @@ jobs:
           java-version: 21
       - name: Set up maven cache
         if: env.GH_TOKEN != null
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-m2-repo-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
Currently the GitHub workflow runs show a warning due to the outdated actions:
> The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3, actions/cache@v3

This pull requests updates those actions and also configures Dependabot to update GitHub actions in the future. I chose "monthly" as interval because most likely there won't be major version changes for the actions that often, so there is no need to check daily or weekly.

Side note: Maybe the `actions/cache` usage could be omitted because `actions/setup-java` also has [support for caching Maven dependencies](https://github.com/actions/setup-java/tree/v4/?tab=readme-ov-file#caching-packages-dependencies).