### PR TITLE
Update Log4j 2 to 2.24.1

### DIFF
--- a/log4j2-propagation/pom.xml
+++ b/log4j2-propagation/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2022 Talsma ICT
+    Copyright 2016-2024 Talsma ICT
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -46,6 +46,12 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>${log4j2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j2.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <spring-security.version>6.3.3</spring-security.version>
         <servlet-api.version>4.0.1</servlet-api.version>
         <slf4j.version>2.0.16</slf4j.version>
-        <log4j2.version>2.23.1</log4j2.version>
+        <log4j2.version>2.24.1</log4j2.version>
 
         <junit.version>5.11.2</junit.version>
         <logback.version>1.5.8</logback.version>


### PR DESCRIPTION
This also needs a test dependency on log4j-core because since version 2.24.0 if no provider implementation is found a no-op ThreadContextMap is used, which causes test failures. See also https://github.com/apache/logging-log4j2/issues/2946#issuecomment-2400972272 for more details.

However, for normal usage that is probably not relevant since there the user most likely will have some variant of Log4j provider, most likely log4j-core as runtime dependency (but possibly also another provider).