### PR TITLE
Fix [applyTo|accept|runAfter]Either(Async)? completion stage uncertainty

### DIFF
--- a/context-propagation-java8/src/main/java/nl/talsmasoftware/context/futures/ContextSnapshotHolder.java
+++ b/context-propagation-java8/src/main/java/nl/talsmasoftware/context/futures/ContextSnapshotHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Talsma ICT
+ * Copyright 2016-2024 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ final class ContextSnapshotHolder implements Consumer<ContextSnapshot>, Supplier
      *                 Optional, if {@code null} the holder will initialize with a new snapshot.
      */
     ContextSnapshotHolder(ContextSnapshot snapshot) {
-        this.accept(snapshot == null ? ContextManagers.createContextSnapshot() : snapshot);
+        this.snapshot = (snapshot == null ? ContextManagers.createContextSnapshot() : snapshot);
     }
 
     /**

--- a/context-propagation/src/main/java/nl/talsmasoftware/context/delegation/Wrapper.java
+++ b/context-propagation/src/main/java/nl/talsmasoftware/context/delegation/Wrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Talsma ICT
+ * Copyright 2016-2024 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ public abstract class Wrapper<T> {
     }
 
     /**
-     * Acessor to provide a guaranteed non-<code>null</code> delegate instance for use within delegation method
+     * Accessor to provide a guaranteed non-<code>null</code> delegate instance for use within delegation method
      * implementations.
      *
      * @return The delegate for this wrapper (guaranteed to be non-<code>null</code>).

--- a/pom.xml
+++ b/pom.xml
@@ -365,7 +365,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -392,6 +396,18 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <repositories>
         <repository>


### PR DESCRIPTION
For ContextAwareCompletableFuture 'either' methods, it is uncertain whether 'this' completion stage will actually complete.

Taking a new context snapshot after this uncertain completion is not attempted. Instead, the most recent snapshot value _at the time of the 'eiter' call_ is propagated to following completion stages in the returned ContextAwareCompletableFuture.

This fixes #499 