### PR TITLE
Several minor fixes.

### DIFF
--- a/context-propagation-api/src/main/java/nl/talsmasoftware/context/api/ContextManager.java
+++ b/context-propagation-api/src/main/java/nl/talsmasoftware/context/api/ContextManager.java
@@ -89,7 +89,7 @@ public interface ContextManager<T> {
      * @since 2.0.0
      */
     static void clearAll() {
-        ContextSnapshotImpl.clearActiveContexts();
+        ContextSnapshotImpl.clearAll();
     }
 
     /**

--- a/context-propagation-api/src/main/java/nl/talsmasoftware/context/api/ContextSnapshotImpl.java
+++ b/context-propagation-api/src/main/java/nl/talsmasoftware/context/api/ContextSnapshotImpl.java
@@ -83,26 +83,14 @@ final class ContextSnapshotImpl implements ContextSnapshot {
     /**
      * Clears all active contexts from the current thread.
      *
-     * <p>
-     * Contexts that are 'stacked' (i.e. restore the previous state upon close) should be
-     * closed in a way that includes all 'parent' contexts as well.
-     *
-     * <p>
-     * This operation is not intended to be used by general application code as it likely breaks any 'stacked'
-     * active context that surrounding code may depend upon.
-     * Appropriate use includes thread management, where threads are reused by some pooling
-     * mechanism. For example, it is considered safe to clear the context when obtaining a 'fresh' thread from a
-     * thread pool (as no context expectations should exist at that point).
-     * An even better strategy would be to clear the context right before returning a used thread to the pool
-     * as this will allow any unclosed contexts to be garbage collected. Besides preventing contextual issues,
-     * this reduces the risk of memory leaks by unbalanced context calls.
+     * @see ContextManager#clearAll()
      */
-    static void clearActiveContexts() {
+    static void clearAll() {
         final long start = System.nanoTime();
         for (ContextManager<?> manager : ServiceCache.cached(ContextManager.class)) {
             clear(manager);
         }
-        timed(System.nanoTime() - start, Context.class, "clearAll", null);
+        timed(System.nanoTime() - start, ContextManager.class, "clearAll", null);
     }
 
     /**

--- a/context-propagation-api/src/main/java/nl/talsmasoftware/context/api/ServiceCache.java
+++ b/context-propagation-api/src/main/java/nl/talsmasoftware/context/api/ServiceCache.java
@@ -88,7 +88,7 @@ final class ServiceCache {
             services.add(service);
         }
         services.trimToSize();
-        // TODO debug logging
+        LOGGER.fine(() -> String.format("Loaded %d %s service implementations: %s.", services.size(), serviceType.getSimpleName(), services));
         return Collections.unmodifiableList(services);
     }
 }


### PR DESCRIPTION
- rename ContextSnapshotImpl.clearActiveContexts to clearAll.
- call correct timer name for ContextManager.clearAll (from ContextSnapshotImpl implementation)
- simplify javadoc for package-protected snapshot implementation by referring to interface docs.
- debug cache misses in ServiceCache to gain insight in ServiceCache functionality.