### PR TITLE
API simplification: Eliminate unnecessary Context generic.

### DIFF
--- a/context-propagation-api/src/main/java/nl/talsmasoftware/context/api/Context.java
+++ b/context-propagation-api/src/main/java/nl/talsmasoftware/context/api/Context.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,11 +40,10 @@ import java.io.Closeable;
  *     but unwinding provides consistent behaviour in case it does happen.
  * </ul>
  *
- * @param <T> Type of the context value.
  * @author Sjoerd Talsma
  * @since 2.0.0
  */
-public interface Context<T> extends Closeable {
+public interface Context extends Closeable {
 
     /**
      * Closes this context.

--- a/context-propagation-api/src/main/java/nl/talsmasoftware/context/api/ContextManager.java
+++ b/context-propagation-api/src/main/java/nl/talsmasoftware/context/api/ContextManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ public interface ContextManager<T> {
      * @return The new <em>active</em> context containing the specified value
      * which should be closed by the caller at the end of its lifecycle from the same thread.
      */
-    Context<T> initializeNewContext(T value);
+    Context initializeNewContext(T value);
 
     /**
      * The value of the currently active context, or {@code null} if no context is active.

--- a/context-propagation-api/src/test/java/nl/talsmasoftware/context/api/ContextSnapshotTest.java
+++ b/context-propagation-api/src/test/java/nl/talsmasoftware/context/api/ContextSnapshotTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,7 +115,7 @@ class ContextSnapshotTest {
     @Test
     void testCreateSnapshot_ExceptionHandling() {
         ThrowingContextManager.onGet = new IllegalStateException("No active context!");
-        Context<String> ctx = new DummyContext("blah");
+        Context ctx = new DummyContext("blah");
         ContextSnapshot snapshot = ContextSnapshot.capture();
         ctx.close();
 
@@ -130,8 +130,8 @@ class ContextSnapshotTest {
     void testReactivateSnapshot_ExceptionHandling() {
         final RuntimeException reactivationException = new IllegalStateException("Cannot create new context!");
         ThrowingContextManager mgr = new ThrowingContextManager();
-        Context<String> ctx1 = new DummyContext("foo");
-        Context<String> ctx2 = mgr.initializeNewContext("bar");
+        Context ctx1 = new DummyContext("foo");
+        Context ctx2 = mgr.initializeNewContext("bar");
         ContextSnapshot snapshot = ContextSnapshot.capture();
         ThrowingContextManager.onInitialize = reactivationException;
 

--- a/context-propagation-api/src/test/java/nl/talsmasoftware/context/api/NoContextManagersTest.java
+++ b/context-propagation-api/src/test/java/nl/talsmasoftware/context/api/NoContextManagersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ public class NoContextManagersTest {
 
     @Test
     public void testReactivate_withoutContextManagers() {
-        Context<String> ctx1 = new DummyContext("foo");
+        Context ctx1 = new DummyContext("foo");
         ContextSnapshot snapshot = ContextSnapshot.capture();
         ctx1.close();
 

--- a/context-propagation-api/src/test/java/nl/talsmasoftware/context/dummy/DummyContext.java
+++ b/context-propagation-api/src/test/java/nl/talsmasoftware/context/dummy/DummyContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * @author Sjoerd Talsma
  */
-public final class DummyContext implements Context<String> {
+public final class DummyContext implements Context {
     private static final ThreadLocal<DummyContext> INSTANCE = new ThreadLocal<>();
 
     private final DummyContext parent;

--- a/context-propagation-api/src/test/java/nl/talsmasoftware/context/dummy/DummyContextManager.java
+++ b/context-propagation-api/src/test/java/nl/talsmasoftware/context/dummy/DummyContextManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import nl.talsmasoftware.context.api.ContextManager;
  */
 public class DummyContextManager implements ContextManager<String> {
 
-    public Context<String> initializeNewContext(String value) {
+    public Context initializeNewContext(String value) {
         return new DummyContext(value);
     }
 

--- a/context-propagation-api/src/test/java/nl/talsmasoftware/context/dummy/ThrowingContextManager.java
+++ b/context-propagation-api/src/test/java/nl/talsmasoftware/context/dummy/ThrowingContextManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ public class ThrowingContextManager implements ContextManager<String> {
     }
 
     @Override
-    public Context<String> initializeNewContext(String value) {
+    public Context initializeNewContext(String value) {
         if (onInitialize != null) try {
             throw onInitialize;
         } finally {
@@ -71,7 +71,7 @@ public class ThrowingContextManager implements ContextManager<String> {
         return getClass().getSimpleName();
     }
 
-    private final static class Ctx implements Context<String> {
+    private final static class Ctx implements Context {
         private static final ThreadLocal<Ctx> STORAGE = new ThreadLocal<>();
 
         private final Ctx parent;

--- a/context-propagation-core/src/main/java/nl/talsmasoftware/context/core/threadlocal/AbstractThreadLocalContext.java
+++ b/context-propagation-core/src/main/java/nl/talsmasoftware/context/core/threadlocal/AbstractThreadLocalContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import java.util.logging.Logger;
  *
  * @author Sjoerd Talsma
  */
-public abstract class AbstractThreadLocalContext<T> implements Context<T> {
+public abstract class AbstractThreadLocalContext<T> implements Context {
     private static final Logger LOGGER = Logger.getLogger(AbstractThreadLocalContext.class.getName());
 
     /**
@@ -53,7 +53,7 @@ public abstract class AbstractThreadLocalContext<T> implements Context<T> {
      * The parent context that was active at the time this context was created (if any)
      * or <code>null</code> in case there was no active context when this context was created.
      */
-    protected final Context<T> parentContext;
+    protected final Context parentContext;
 
     /**
      * The actual value, so subclasses can access it.<br>

--- a/context-propagation-core/src/test/java/nl/talsmasoftware/context/clearable/ClearableDummyContextManager.java
+++ b/context-propagation-core/src/test/java/nl/talsmasoftware/context/clearable/ClearableDummyContextManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ public class ClearableDummyContextManager implements ContextManager<String> {
         return current != null ? current.getValue() : null;
     }
 
-    public Context<String> initializeNewContext(String value) {
+    public Context initializeNewContext(String value) {
         return new DummyContext(value);
     }
 
@@ -34,7 +34,7 @@ public class ClearableDummyContextManager implements ContextManager<String> {
         CTX.remove();
     }
 
-    private static class DummyContext implements Context<String> {
+    private static class DummyContext implements Context {
         private final DummyContext previous;
         private String value;
 

--- a/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/ContextSnapshotTest.java
+++ b/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/ContextSnapshotTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,9 +38,9 @@ public class ContextSnapshotTest {
 
     @Test
     public void testSnapshotReactivate() {
-        try (Context<String> ctx = MGR.initializeNewContext("Old value")) {
+        try (Context ctx = MGR.initializeNewContext("Old value")) {
             ContextSnapshot snapshot = ContextSnapshot.capture();
-            try (Context<String> ctx2 = MGR.initializeNewContext("New value")) {
+            try (Context ctx2 = MGR.initializeNewContext("New value")) {
                 assertThat(MGR.getActiveContextValue(), is("New value"));
 
                 try (ContextSnapshot.Reactivation reactivation = snapshot.reactivate()) {

--- a/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/NoContextManagersTest.java
+++ b/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/NoContextManagersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ public class NoContextManagersTest {
 
     @Test
     public void testReactivate_withoutContextManagers() {
-        Context<String> ctx1 = new DummyContext("foo");
+        Context ctx1 = new DummyContext("foo");
         ContextSnapshot snapshot = ContextSnapshot.capture();
         ctx1.close();
 

--- a/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/concurrent/ContextAwareCompletableFutureTest.java
+++ b/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/concurrent/ContextAwareCompletableFutureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testDefaultConstructor() throws ExecutionException, InterruptedException {
-        Context<String> ctx = manager.initializeNewContext("foo");
+        Context ctx = manager.initializeNewContext("foo");
         CompletableFuture<String> future1 = new ContextAwareCompletableFuture<>(); // should have a new snapshot with foo
         ctx.close();
 
@@ -94,7 +94,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testSupplyAsync() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Vincent Vega")) {
+        try (Context ctx = manager.initializeNewContext("Vincent Vega")) {
             Future<String> future = supplyAsync(DummyContext::currentValue);
             assertThat(future.get(), is("Vincent Vega"));
         }
@@ -102,7 +102,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testSupplyAsync_executor() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Marcellus Wallace")) {
+        try (Context ctx = manager.initializeNewContext("Marcellus Wallace")) {
             Future<String> future = supplyAsync(DummyContext::currentValue, contextUnawareThreadpool);
             assertThat(future.get(), is("Marcellus Wallace"));
         }
@@ -110,7 +110,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testSupplyAsync_executor_snapshot() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Vincent Vega")) {
+        try (Context ctx = manager.initializeNewContext("Vincent Vega")) {
             ContextSnapshot snapshot = ContextSnapshot.capture();
             DummyContext.setCurrentValue("Jules Winnfield");
             assertContext("Jules Winnfield");
@@ -122,7 +122,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testSupplyAsync_executor_snapshot_takeNewSnapshot() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Vincent Vega")) {
+        try (Context ctx = manager.initializeNewContext("Vincent Vega")) {
             ContextSnapshot snapshot = ContextSnapshot.capture();
             DummyContext.setCurrentValue("Jules Winnfield");
             assertContext("Jules Winnfield");
@@ -142,7 +142,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testRunAsync() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Mia Wallace")) {
+        try (Context ctx = manager.initializeNewContext("Mia Wallace")) {
             ContextAwareCompletableFuture<Void> future = ContextAwareCompletableFuture.runAsync(() -> assertThat(DummyContext.currentValue(), is("Mia Wallace")));
             future.get(); // trigger asynchronous assertion
         }
@@ -150,7 +150,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testRunAsync_executor() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Jimmie")) {
+        try (Context ctx = manager.initializeNewContext("Jimmie")) {
             ContextAwareCompletableFuture<Void> future = ContextAwareCompletableFuture.runAsync(() -> assertThat(DummyContext.currentValue(), is("Jimmie")), contextUnawareThreadpool);
             future.get(); // trigger asynchronous assertion
         }
@@ -158,7 +158,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testRunAsync_executor_snapshot() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Pumpkin")) {
+        try (Context ctx = manager.initializeNewContext("Pumpkin")) {
             ContextSnapshot snapshot = ContextSnapshot.capture();
             DummyContext.setCurrentValue("Honey Bunny");
             assertContext("Honey Bunny");
@@ -170,7 +170,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testRunAsync_executor_snapshot_takeNewSnapshot() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Pumpkin")) {
+        try (Context ctx = manager.initializeNewContext("Pumpkin")) {
             ContextSnapshot snapshot = ContextSnapshot.capture();
             DummyContext.setCurrentValue("Honey Bunny");
             assertContext("Honey Bunny");
@@ -186,14 +186,14 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenApply() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Jimmie")) {
+        try (Context ctx = manager.initializeNewContext("Jimmie")) {
             Future<String> future = ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Bonnie"))
                     .thenApply(voidvalue -> DummyContext.currentValue());
             assertThat(future.get(), is("Jimmie"));
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Jimmie")) {
+        try (Context ctx = manager.initializeNewContext("Jimmie")) {
             Future<String> future = ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Bonnie"), null, null, true)
                     .thenApply(voidvalue -> DummyContext.currentValue());
@@ -203,14 +203,14 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenApplyAsync() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Butch")) {
+        try (Context ctx = manager.initializeNewContext("Butch")) {
             Future<String> future = ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Esmerelda Villalobos"))
                     .thenApplyAsync(voidvalue -> DummyContext.currentValue());
             assertThat(future.get(), is("Butch"));
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Butch")) {
+        try (Context ctx = manager.initializeNewContext("Butch")) {
             Future<String> future = ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Esmerelda Villalobos"), null, null, true)
                     .thenApplyAsync(voidvalue -> DummyContext.currentValue());
@@ -220,14 +220,14 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenApplyAsync_executor() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Maynard")) {
+        try (Context ctx = manager.initializeNewContext("Maynard")) {
             Future<String> future = ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Zed"))
                     .thenApplyAsync(voidvalue -> DummyContext.currentValue(), contextUnawareThreadpool);
             assertThat(future.get(), is("Maynard"));
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Maynard")) {
+        try (Context ctx = manager.initializeNewContext("Maynard")) {
             Future<String> future = ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Zed"), null, null, true)
                     .thenApplyAsync(voidvalue -> DummyContext.currentValue(), contextUnawareThreadpool);
@@ -237,7 +237,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenApplyAndTakeNewSnapshot() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Jimmie")) {
+        try (Context ctx = manager.initializeNewContext("Jimmie")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Bonnie")).takeNewSnapshot().thenApply(voidvalue -> {
                 String val = DummyContext.currentValue();
                 DummyContext.setCurrentValue("-" + val);
@@ -248,7 +248,7 @@ public class ContextAwareCompletableFutureTest {
             }).get();
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Jimmie")) {
+        try (Context ctx = manager.initializeNewContext("Jimmie")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Bonnie"), null, null, true).thenApply(voidvalue -> {
                 String val = DummyContext.currentValue();
                 DummyContext.setCurrentValue("-" + val);
@@ -262,7 +262,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenApplyAsyncAndTakeNewSnapshot() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Butch")) {
+        try (Context ctx = manager.initializeNewContext("Butch")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Esmerelda Villalobos")).takeNewSnapshot().thenApplyAsync(voidvalue -> {
                 String val = DummyContext.currentValue();
                 DummyContext.setCurrentValue("-" + val);
@@ -273,7 +273,7 @@ public class ContextAwareCompletableFutureTest {
             }).get();
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Butch")) {
+        try (Context ctx = manager.initializeNewContext("Butch")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Esmerelda Villalobos"), null, null, true).thenApplyAsync(voidvalue -> {
                 String val = DummyContext.currentValue();
                 DummyContext.setCurrentValue("-" + val);
@@ -287,7 +287,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenApplyAsyncAndTakeNewSnapshot_executor() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Maynard")) {
+        try (Context ctx = manager.initializeNewContext("Maynard")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Zed")).takeNewSnapshot().thenApplyAsync(voidvalue -> {
                 String val = DummyContext.currentValue();
                 DummyContext.setCurrentValue("-" + val);
@@ -298,7 +298,7 @@ public class ContextAwareCompletableFutureTest {
             }).get();
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Maynard")) {
+        try (Context ctx = manager.initializeNewContext("Maynard")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Zed"), null, null, true).thenApplyAsync(voidvalue -> {
                 String val = DummyContext.currentValue();
                 DummyContext.setCurrentValue("-" + val);
@@ -312,13 +312,13 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenAccept() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("The Gimp")) {
+        try (Context ctx = manager.initializeNewContext("The Gimp")) {
             Future<Void> future = ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Butch"))
                     .thenAccept(voidvalue -> assertThat(DummyContext.currentValue(), is("The Gimp")));
             future.get(); // trigger asynchronous assertion
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("The Gimp")) {
+        try (Context ctx = manager.initializeNewContext("The Gimp")) {
             Future<Void> future = ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Butch"), null, null, true)
                     .thenAccept(voidvalue -> assertThat(DummyContext.currentValue(), is("Butch")));
             future.get(); // trigger asynchronous assertion
@@ -327,14 +327,14 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenAcceptAsync() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Butch")) {
+        try (Context ctx = manager.initializeNewContext("Butch")) {
             Future<Void> future = ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Fabienne"))
                     .thenAcceptAsync(voidvalue -> assertThat(DummyContext.currentValue(), is("Butch")));
             future.get(); // trigger asynchronous assertion
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Butch")) {
+        try (Context ctx = manager.initializeNewContext("Butch")) {
             Future<Void> future = ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Fabienne"), null, null, true)
                     .thenAcceptAsync(voidvalue -> assertThat(DummyContext.currentValue(), is("Fabienne")));
@@ -344,14 +344,14 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenAcceptAsync_executor() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Marvin")) {
+        try (Context ctx = manager.initializeNewContext("Marvin")) {
             Future<Void> future = ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Winston Wolfe"))
                     .thenAcceptAsync(voidvalue -> assertThat(DummyContext.currentValue(), is("Marvin")), contextUnawareThreadpool);
             future.get(); // trigger asynchronous assertion
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Marvin")) {
+        try (Context ctx = manager.initializeNewContext("Marvin")) {
             Future<Void> future = ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Winston Wolfe"), null, null, true)
                     .thenAcceptAsync(voidvalue -> assertThat(DummyContext.currentValue(), is("Winston Wolfe")), contextUnawareThreadpool);
@@ -361,7 +361,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenAcceptAndTakeNewSnapshot() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("The Gimp")) {
+        try (Context ctx = manager.initializeNewContext("The Gimp")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Butch")).takeNewSnapshot().thenAccept(voidvalue -> {
                         String val = DummyContext.currentValue();
                         assertThat(val, is("The Gimp"));
@@ -370,7 +370,7 @@ public class ContextAwareCompletableFutureTest {
                     .get(); // trigger asynchronous assertion
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("The Gimp")) {
+        try (Context ctx = manager.initializeNewContext("The Gimp")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Butch"), null, null, true).thenAccept(voidvalue -> {
                         String val = DummyContext.currentValue();
                         assertThat(val, is("Butch"));
@@ -382,7 +382,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenAcceptAsynAndTakeNewSnapshot() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Butch")) {
+        try (Context ctx = manager.initializeNewContext("Butch")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Fabienne")).takeNewSnapshot().thenAcceptAsync(voidvalue -> {
                         String val = DummyContext.currentValue();
                         assertThat(val, is("Butch"));
@@ -391,7 +391,7 @@ public class ContextAwareCompletableFutureTest {
                     .get(); // trigger asynchronous assertion
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Butch")) {
+        try (Context ctx = manager.initializeNewContext("Butch")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Fabienne"), null, null, true).thenAcceptAsync(voidvalue -> {
                         String val = DummyContext.currentValue();
                         assertThat(val, is("Fabienne"));
@@ -403,7 +403,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenAcceptAsyncAndTakeNewSnapshot_executor() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Marvin")) {
+        try (Context ctx = manager.initializeNewContext("Marvin")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Winston Wolfe")).takeNewSnapshot().thenAcceptAsync(voidvalue -> {
                         String val = DummyContext.currentValue();
                         assertThat(val, is("Marvin"));
@@ -413,7 +413,7 @@ public class ContextAwareCompletableFutureTest {
                     .get(); // trigger asynchronous assertion
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Marvin")) {
+        try (Context ctx = manager.initializeNewContext("Marvin")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Winston Wolfe"), null, null, true).thenAcceptAsync(voidvalue -> {
                         String val = DummyContext.currentValue();
                         assertThat(val, is("Winston Wolfe"));
@@ -425,12 +425,12 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenRun() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Lance")) {
+        try (Context ctx = manager.initializeNewContext("Lance")) {
             Future<Void> future = ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Jody")).thenRun(() -> assertThat(DummyContext.currentValue(), is("Lance")));
             future.get(); // trigger asynchronous assertion
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Lance")) {
+        try (Context ctx = manager.initializeNewContext("Lance")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Jody"), null, null, true)
                     .thenRun(() -> assertThat(DummyContext.currentValue(), is("Jody")))
@@ -440,13 +440,13 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenRunAsync() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Ringo")) {
+        try (Context ctx = manager.initializeNewContext("Ringo")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Yolanda"))
                     .thenRunAsync(() -> assertThat(DummyContext.currentValue(), is("Ringo")))
                     .get(); // trigger asynchronous assertion
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Ringo")) {
+        try (Context ctx = manager.initializeNewContext("Ringo")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Yolanda"), null, null, true)
                     .thenRunAsync(() -> assertThat(DummyContext.currentValue(), is("Yolanda")))
@@ -456,14 +456,14 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenRunAsync_executor() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Capt. Koons")) {
+        try (Context ctx = manager.initializeNewContext("Capt. Koons")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Butch"))
                     .thenRunAsync(() -> assertThat(DummyContext.currentValue(), is("Capt. Koons")), contextUnawareThreadpool)
                     .get(); // trigger asynchronous assertion
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Capt. Koons")) {
+        try (Context ctx = manager.initializeNewContext("Capt. Koons")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Butch"), null, null, true)
                     .thenRunAsync(() -> assertThat(DummyContext.currentValue(), is("Butch")), contextUnawareThreadpool)
@@ -473,7 +473,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenRunAndTakeNewSnapshot() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Lance")) {
+        try (Context ctx = manager.initializeNewContext("Lance")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Jody"))
                     .takeNewSnapshot()
@@ -486,7 +486,7 @@ public class ContextAwareCompletableFutureTest {
                     .get(); // trigger asynchronous assertion
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Lance")) {
+        try (Context ctx = manager.initializeNewContext("Lance")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Jody"), null, null, true)
                     .thenRun(() -> {
@@ -501,7 +501,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenRunAsyncAndTakeNewSnapshot() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Ringo")) {
+        try (Context ctx = manager.initializeNewContext("Ringo")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Yolanda"))
                     .takeNewSnapshot()
@@ -514,7 +514,7 @@ public class ContextAwareCompletableFutureTest {
                     .get(); // trigger asynchronous assertion
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Ringo")) {
+        try (Context ctx = manager.initializeNewContext("Ringo")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Yolanda"), null, null, true)
                     .thenRunAsync(() -> {
@@ -529,7 +529,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenRunAsyncAndTakeNewSnapshot_executor() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Capt. Koons")) {
+        try (Context ctx = manager.initializeNewContext("Capt. Koons")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Butch"))
                     .takeNewSnapshot()
@@ -542,7 +542,7 @@ public class ContextAwareCompletableFutureTest {
                     .get(); // trigger asynchronous assertion
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Capt. Koons")) {
+        try (Context ctx = manager.initializeNewContext("Capt. Koons")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Butch"), null, null, true)
                     .thenRunAsync(() -> {
@@ -557,14 +557,14 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testWhenComplete() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Butch")) {
+        try (Context ctx = manager.initializeNewContext("Butch")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Floyd"))
                     .whenComplete((voidValue, exception) -> assertThat(DummyContext.currentValue(), is("Butch")))
                     .get(); // trigger asynchronous assertion
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Butch")) {
+        try (Context ctx = manager.initializeNewContext("Butch")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Floyd"), null, null, true)
                     .whenComplete((voidValue, exception) -> assertThat(DummyContext.currentValue(), is("Floyd")))
@@ -574,14 +574,14 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testWhenCompleteAsync() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Zed")) {
+        try (Context ctx = manager.initializeNewContext("Zed")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Pipe hittin' niggers"))
                     .whenCompleteAsync((voidValue, exception) -> assertThat(DummyContext.currentValue(), is("Zed")))
                     .get(); // trigger asynchronous assertion
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Zed")) {
+        try (Context ctx = manager.initializeNewContext("Zed")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Pipe hittin' niggers"), null, null, true)
                     .whenCompleteAsync((voidValue, exception) -> assertThat(DummyContext.currentValue(), is("Pipe hittin' niggers")))
@@ -591,14 +591,14 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testWhenCompleteAsync_executor() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Butch")) {
+        try (Context ctx = manager.initializeNewContext("Butch")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Floyd"))
                     .whenCompleteAsync((voidValue, exception) -> assertThat(DummyContext.currentValue(), is("Butch")), contextUnawareThreadpool)
                     .get(); // trigger asynchronous assertion
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Butch")) {
+        try (Context ctx = manager.initializeNewContext("Butch")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Floyd"), null, null, true)
                     .whenCompleteAsync((voidValue, exception) -> assertThat(DummyContext.currentValue(), is("Floyd")), contextUnawareThreadpool)
@@ -609,14 +609,14 @@ public class ContextAwareCompletableFutureTest {
     @Test
     public void testHandle() throws ExecutionException, InterruptedException {
         final RuntimeException exception = new RuntimeException("Bad Motherfucker");
-        try (Context<String> ctx = manager.initializeNewContext("Jody")) {
+        try (Context ctx = manager.initializeNewContext("Jody")) {
             assertThat(ContextAwareCompletableFuture.runAsync(() -> {
                 DummyContext.setCurrentValue("Trudy");
                 throw exception;
             }).handleAsync((voidValue, throwable) -> manager.getActiveContextValue()).get(), is("Jody"));
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Jody")) {
+        try (Context ctx = manager.initializeNewContext("Jody")) {
             assertThat(ContextAwareCompletableFuture.runAsync(() -> {
                 DummyContext.setCurrentValue("Trudy");
                 throw exception;
@@ -627,14 +627,14 @@ public class ContextAwareCompletableFutureTest {
     @Test
     public void testHandleAsync() throws ExecutionException, InterruptedException {
         final RuntimeException exception = new RuntimeException("Bad Motherfucker");
-        try (Context<String> ctx = manager.initializeNewContext("Jody")) {
+        try (Context ctx = manager.initializeNewContext("Jody")) {
             assertThat(ContextAwareCompletableFuture.runAsync(() -> {
                 DummyContext.setCurrentValue("Trudy");
                 throw exception;
             }).handleAsync((voidValue, throwable) -> manager.getActiveContextValue()).get(), is("Jody"));
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Jody")) {
+        try (Context ctx = manager.initializeNewContext("Jody")) {
             assertThat(ContextAwareCompletableFuture.runAsync(() -> {
                 DummyContext.setCurrentValue("Trudy");
                 throw exception;
@@ -645,14 +645,14 @@ public class ContextAwareCompletableFutureTest {
     @Test
     public void testHandleAsync_executor() throws ExecutionException, InterruptedException {
         final RuntimeException exception = new RuntimeException("Bad Motherfucker");
-        try (Context<String> ctx = manager.initializeNewContext("Jody")) {
+        try (Context ctx = manager.initializeNewContext("Jody")) {
             assertThat(ContextAwareCompletableFuture.runAsync(() -> {
                 DummyContext.setCurrentValue("Trudy");
                 throw exception;
             }).handleAsync((voidValue, throwable) -> manager.getActiveContextValue(), contextUnawareThreadpool).get(), is("Jody"));
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Jody")) {
+        try (Context ctx = manager.initializeNewContext("Jody")) {
             assertThat(ContextAwareCompletableFuture.runAsync(() -> {
                 DummyContext.setCurrentValue("Trudy");
                 throw exception;
@@ -663,7 +663,7 @@ public class ContextAwareCompletableFutureTest {
     @Test
     public void testHandleAndTakeSnapshot() throws ExecutionException, InterruptedException {
         final RuntimeException exception = new RuntimeException("Bad Motherfucker");
-        try (Context<String> ctx = manager.initializeNewContext("Jody")) {
+        try (Context ctx = manager.initializeNewContext("Jody")) {
             assertThat(ContextAwareCompletableFuture.runAsync(() -> {
                 DummyContext.setCurrentValue("Trudy");
                 throw exception;
@@ -674,7 +674,7 @@ public class ContextAwareCompletableFutureTest {
             }).whenComplete((result, throwable) -> assertContext("-Jody")).get(), is("Jody"));
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Jody")) {
+        try (Context ctx = manager.initializeNewContext("Jody")) {
             assertThat(ContextAwareCompletableFuture.runAsync(() -> {
                 DummyContext.setCurrentValue("Trudy");
                 throw exception;
@@ -689,7 +689,7 @@ public class ContextAwareCompletableFutureTest {
     @Test
     public void testHandleAsyncAndTakeSnapshot() throws ExecutionException, InterruptedException {
         final RuntimeException exception = new RuntimeException("Bad Motherfucker");
-        try (Context<String> ctx = manager.initializeNewContext("Jody")) {
+        try (Context ctx = manager.initializeNewContext("Jody")) {
             assertThat(ContextAwareCompletableFuture.runAsync(() -> {
                 DummyContext.setCurrentValue("Trudy");
                 throw exception;
@@ -700,7 +700,7 @@ public class ContextAwareCompletableFutureTest {
             }).whenComplete((result, throwable) -> assertContext("-Jody")).get(), is("Jody"));
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Jody")) {
+        try (Context ctx = manager.initializeNewContext("Jody")) {
             assertThat(ContextAwareCompletableFuture.runAsync(() -> {
                 DummyContext.setCurrentValue("Trudy");
                 throw exception;
@@ -715,7 +715,7 @@ public class ContextAwareCompletableFutureTest {
     @Test
     public void testHandleAsyncAndTakeSnapshot_executor() throws ExecutionException, InterruptedException {
         final RuntimeException exception = new RuntimeException("Bad Motherfucker");
-        try (Context<String> ctx = manager.initializeNewContext("Jody")) {
+        try (Context ctx = manager.initializeNewContext("Jody")) {
             assertThat(ContextAwareCompletableFuture.runAsync(() -> {
                 DummyContext.setCurrentValue("Trudy");
                 throw exception;
@@ -726,7 +726,7 @@ public class ContextAwareCompletableFutureTest {
             }, contextUnawareThreadpool).whenComplete((result, throwable) -> assertContext("-Jody")).get(), is("Jody"));
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Jody")) {
+        try (Context ctx = manager.initializeNewContext("Jody")) {
             assertThat(ContextAwareCompletableFuture.runAsync(() -> {
                 DummyContext.setCurrentValue("Trudy");
                 throw exception;
@@ -740,7 +740,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testExceptionally() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Gringo")) {
+        try (Context ctx = manager.initializeNewContext("Gringo")) {
             ContextAwareCompletableFuture.runAsync(() -> {
                 DummyContext.setCurrentValue("Jules Winnfield");
                 throw new RuntimeException("Bad Motherfucker");
@@ -751,7 +751,7 @@ public class ContextAwareCompletableFutureTest {
             }).get();
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Gringo")) {
+        try (Context ctx = manager.initializeNewContext("Gringo")) {
             ContextAwareCompletableFuture.runAsync(() -> {
                 DummyContext.setCurrentValue("Jules Winnfield");
                 throw new RuntimeException("Bad Motherfucker");
@@ -765,7 +765,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testExceptionallyAndTakeNewSnapshot() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Gringo")) {
+        try (Context ctx = manager.initializeNewContext("Gringo")) {
             ContextAwareCompletableFuture.runAsync(() -> {
                 DummyContext.setCurrentValue("Jules Winnfield");
                 throw new RuntimeException("Bad Motherfucker");
@@ -777,7 +777,7 @@ public class ContextAwareCompletableFutureTest {
             }).thenAccept(aVoid -> assertContext("-Gringo")).get();
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Gringo")) {
+        try (Context ctx = manager.initializeNewContext("Gringo")) {
             ContextAwareCompletableFuture.runAsync(() -> {
                 DummyContext.setCurrentValue("Jules Winnfield");
                 throw new RuntimeException("Bad Motherfucker");
@@ -792,7 +792,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenCombine() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Marcellus Wallace")) {
+        try (Context ctx = manager.initializeNewContext("Marcellus Wallace")) {
             Future<String> future = ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Vincent Vega"))
                     .thenCombine(ContextAwareCompletableFuture
@@ -801,7 +801,7 @@ public class ContextAwareCompletableFutureTest {
             assertThat(DummyContext.currentValue(), is("Marcellus Wallace"));
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Marcellus Wallace")) {
+        try (Context ctx = manager.initializeNewContext("Marcellus Wallace")) {
             Future<String> future = ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Vincent Vega"), null, null, true)
                     .thenCombine(ContextAwareCompletableFuture
@@ -813,7 +813,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenCombineAsync() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Brett")) {
+        try (Context ctx = manager.initializeNewContext("Brett")) {
             Future<String> future = ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Marvin"))
                     .thenCombineAsync(ContextAwareCompletableFuture
@@ -822,7 +822,7 @@ public class ContextAwareCompletableFutureTest {
             assertThat(DummyContext.currentValue(), is("Brett"));
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Brett")) {
+        try (Context ctx = manager.initializeNewContext("Brett")) {
             Future<String> future = ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Marvin"), null, null, true)
                     .thenCombineAsync(ContextAwareCompletableFuture
@@ -834,7 +834,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenCombineAsync_executor() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Brett")) {
+        try (Context ctx = manager.initializeNewContext("Brett")) {
             Future<String> future = ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Marvin"))
                     .thenCombineAsync(ContextAwareCompletableFuture
@@ -843,7 +843,7 @@ public class ContextAwareCompletableFutureTest {
             assertThat(DummyContext.currentValue(), is("Brett"));
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Brett")) {
+        try (Context ctx = manager.initializeNewContext("Brett")) {
             Future<String> future = ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Marvin"), null, null, true)
                     .thenCombineAsync(ContextAwareCompletableFuture
@@ -855,7 +855,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenCombineAndTakeNewSnapshot() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Marcellus Wallace")) {
+        try (Context ctx = manager.initializeNewContext("Marcellus Wallace")) {
             Future<String> future = ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Vincent Vega"))
                     .takeNewSnapshot()
@@ -868,7 +868,7 @@ public class ContextAwareCompletableFutureTest {
             assertThat(future.get(), is("Marcellus Wallace"));
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Marcellus Wallace")) {
+        try (Context ctx = manager.initializeNewContext("Marcellus Wallace")) {
             Future<String> future = ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Vincent Vega"), null, null, true).thenCombine(ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Jules Winnfield")), (voidA, voidB) -> {
                 String val = DummyContext.currentValue();
                 DummyContext.setCurrentValue("-" + val);
@@ -881,7 +881,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenCombineAsyncAndTakeNewSnapshot() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Brett")) {
+        try (Context ctx = manager.initializeNewContext("Brett")) {
             Future<String> future = ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Marvin")).takeNewSnapshot().thenCombineAsync(ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Flock of Seagulls")), (voidA, voidB) -> {
                 String val = DummyContext.currentValue();
                 DummyContext.setCurrentValue("-" + val);
@@ -892,7 +892,7 @@ public class ContextAwareCompletableFutureTest {
             assertThat(DummyContext.currentValue(), is("Brett"));
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Brett")) {
+        try (Context ctx = manager.initializeNewContext("Brett")) {
             Future<String> future = ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Marvin"), null, null, true).thenCombineAsync(ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Flock of Seagulls")), (voidA, voidB) -> {
                 String val = DummyContext.currentValue();
                 DummyContext.setCurrentValue("-" + val);
@@ -906,7 +906,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenCombineAsyncAndTakeNewSnapshot_executor() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Brett")) {
+        try (Context ctx = manager.initializeNewContext("Brett")) {
             Future<String> future = ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Marvin")).takeNewSnapshot().thenCombineAsync(ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Flock of Seagulls")), (voidA, voidB) -> {
                 String val = DummyContext.currentValue();
                 DummyContext.setCurrentValue("-" + val);
@@ -917,7 +917,7 @@ public class ContextAwareCompletableFutureTest {
             assertThat(DummyContext.currentValue(), is("Brett"));
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Brett")) {
+        try (Context ctx = manager.initializeNewContext("Brett")) {
             Future<String> future = ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Marvin"), null, null, true).thenCombineAsync(ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Flock of Seagulls")), (voidA, voidB) -> {
                 String val = DummyContext.currentValue();
                 DummyContext.setCurrentValue("-" + val);
@@ -931,7 +931,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenAcceptBoth() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Pulp Fiction")) {
+        try (Context ctx = manager.initializeNewContext("Pulp Fiction")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Quentin"), null, null, true)
                     .thenAcceptBoth(completedFuture("Tarantino"), (Void voidA, String stringB) -> assertThat(manager.getActiveContextValue() + stringB, is("QuentinTarantino")))
@@ -942,7 +942,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenAcceptBothAsync() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Pulp Fiction")) {
+        try (Context ctx = manager.initializeNewContext("Pulp Fiction")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Quentin"), null, null, true)
                     .thenAcceptBothAsync(completedFuture("Tarantino"), (Void voidA, String stringB) -> assertThat(manager.getActiveContextValue() + stringB, is("QuentinTarantino")))
@@ -953,7 +953,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenAcceptBothAsync_executor() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Pulp Fiction")) {
+        try (Context ctx = manager.initializeNewContext("Pulp Fiction")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Quentin"), null, null, true)
                     .thenAcceptBothAsync(completedFuture("Tarantino"), (Void voidA, String stringB) -> assertThat(manager.getActiveContextValue() + stringB, is("QuentinTarantino")), contextUnawareThreadpool)
@@ -964,7 +964,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenAcceptBothAndTakeNewSnapshot() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Pulp Fiction")) {
+        try (Context ctx = manager.initializeNewContext("Pulp Fiction")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Quentin"))
                     .takeNewSnapshot()
@@ -977,7 +977,7 @@ public class ContextAwareCompletableFutureTest {
                     .get();
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Pulp Fiction")) {
+        try (Context ctx = manager.initializeNewContext("Pulp Fiction")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Quentin"), null, null, true)
                     .thenAcceptBoth(completedFuture(" by Tarantino"), (Void voidA, String stringB) -> {
@@ -992,7 +992,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenAcceptBothAsyncAndTakeNewSnapshot() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Pulp Fiction")) {
+        try (Context ctx = manager.initializeNewContext("Pulp Fiction")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Quentin"))
                     .takeNewSnapshot()
@@ -1005,7 +1005,7 @@ public class ContextAwareCompletableFutureTest {
                     .get();
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Pulp Fiction")) {
+        try (Context ctx = manager.initializeNewContext("Pulp Fiction")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Quentin"), null, null, true)
                     .thenAcceptBoth(completedFuture("Tarantino"), (Void voidA, String stringB) -> {
@@ -1020,7 +1020,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenAcceptBothAsyncAndTakeNewSnapshot_executor() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Pulp Fiction")) {
+        try (Context ctx = manager.initializeNewContext("Pulp Fiction")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Quentin"))
                     .takeNewSnapshot()
@@ -1034,7 +1034,7 @@ public class ContextAwareCompletableFutureTest {
             assertContext("Pulp Fiction");
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("Pulp Fiction")) {
+        try (Context ctx = manager.initializeNewContext("Pulp Fiction")) {
             ContextAwareCompletableFuture
                     .runAsync(() -> DummyContext.setCurrentValue("Quentin"), null, null, true)
                     .thenAcceptBothAsync(completedFuture("Tarantino"), (Void voidA, String stringB) -> {
@@ -1050,40 +1050,40 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testRunAfterBoth() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("French Fries")) {
+        try (Context ctx = manager.initializeNewContext("French Fries")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Ketchup")).runAfterBoth(ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Mayonaise")), () -> assertContext("French Fries")).get();
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("French Fries")) {
+        try (Context ctx = manager.initializeNewContext("French Fries")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Ketchup"), null, null, true).runAfterBoth(ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Mayonaise")), () -> assertContext("Ketchup")).get();
         }
     }
 
     @Test
     public void testRunAfterBothAsync() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("French Fries")) {
+        try (Context ctx = manager.initializeNewContext("French Fries")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Ketchup")).runAfterBothAsync(ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Mayonaise")), () -> assertContext("French Fries")).get();
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("French Fries")) {
+        try (Context ctx = manager.initializeNewContext("French Fries")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Ketchup"), null, null, true).runAfterBothAsync(ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Mayonaise")), () -> assertContext("Ketchup")).get();
         }
     }
 
     @Test
     public void testRunAfterBothAsync_executor() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("French Fries")) {
+        try (Context ctx = manager.initializeNewContext("French Fries")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Ketchup")).runAfterBothAsync(ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Mayonaise")), () -> assertContext("French Fries"), contextUnawareThreadpool).get();
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("French Fries")) {
+        try (Context ctx = manager.initializeNewContext("French Fries")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Ketchup"), null, null, true).runAfterBothAsync(ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Mayonaise")), () -> assertContext("Ketchup"), contextUnawareThreadpool).get();
         }
     }
 
     @Test
     public void testRunAfterBothAndTakeNewSnapshot() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("French Fries")) {
+        try (Context ctx = manager.initializeNewContext("French Fries")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Ketchup")).takeNewSnapshot().runAfterBoth(ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Mayonaise")), () -> {
                 String val = manager.getActiveContextValue();
                 assertThat(val, is("French Fries"));
@@ -1091,7 +1091,7 @@ public class ContextAwareCompletableFutureTest {
             }).thenAccept(aVoid -> assertContext("-French Fries")).get();
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("French Fries")) {
+        try (Context ctx = manager.initializeNewContext("French Fries")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Ketchup"), null, null, true).runAfterBoth(ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Mayonaise")), () -> {
                 String val = manager.getActiveContextValue();
                 assertThat(val, is("Ketchup"));
@@ -1102,7 +1102,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testRunAfterBothAsyncAndTakeNewSnapshot() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("French Fries")) {
+        try (Context ctx = manager.initializeNewContext("French Fries")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Ketchup")).takeNewSnapshot().runAfterBothAsync(ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Mayonaise")), () -> {
                 String val = manager.getActiveContextValue();
                 assertThat(val, is("French Fries"));
@@ -1110,7 +1110,7 @@ public class ContextAwareCompletableFutureTest {
             }).thenAccept(aVoid -> assertContext("-French Fries")).get();
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("French Fries")) {
+        try (Context ctx = manager.initializeNewContext("French Fries")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Ketchup"), null, null, true).runAfterBothAsync(ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Mayonaise")), () -> {
                 String val = manager.getActiveContextValue();
                 assertThat(val, is("Ketchup"));
@@ -1121,7 +1121,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testRunAfterBothAsyncAndTakeNewSnapshot_executor() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("French Fries")) {
+        try (Context ctx = manager.initializeNewContext("French Fries")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Ketchup")).takeNewSnapshot().runAfterBothAsync(ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Mayonaise")), () -> {
                 String val = manager.getActiveContextValue();
                 assertThat(val, is("French Fries"));
@@ -1129,7 +1129,7 @@ public class ContextAwareCompletableFutureTest {
             }, contextUnawareThreadpool).thenAccept(aVoid -> assertContext("-French Fries")).get();
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("French Fries")) {
+        try (Context ctx = manager.initializeNewContext("French Fries")) {
             ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Ketchup"), null, null, true).runAfterBothAsync(ContextAwareCompletableFuture.runAsync(() -> DummyContext.setCurrentValue("Mayonaise")), () -> {
                 String val = manager.getActiveContextValue();
                 assertThat(val, is("Ketchup"));
@@ -1141,7 +1141,7 @@ public class ContextAwareCompletableFutureTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void testApplyToEither(boolean takeNewSnapshot) throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Parent")) {
+        try (Context ctx = manager.initializeNewContext("Parent")) {
             // prepare
             ContextAwareCompletableFuture<String> future1 = supplyAsync(stringSupplier("Function 1", "Parent"));
             ContextAwareCompletableFuture<String> future2 = supplyAsync(stringSupplier("Function 2", "Parent"));
@@ -1157,7 +1157,7 @@ public class ContextAwareCompletableFutureTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void testApplyToEitherAsync(boolean takeNewSnapshot) throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Parent")) {
+        try (Context ctx = manager.initializeNewContext("Parent")) {
             // prepare
             ContextAwareCompletableFuture<String> future1 = supplyAsync(stringSupplier("Function 1", "Parent"));
             ContextAwareCompletableFuture<String> future2 = supplyAsync(stringSupplier("Function 2", "Parent"));
@@ -1173,7 +1173,7 @@ public class ContextAwareCompletableFutureTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void testApplyToEitherAsync_executor(boolean takeNewSnapshot) throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("Parent")) {
+        try (Context ctx = manager.initializeNewContext("Parent")) {
             // prepare
             ContextAwareCompletableFuture<String> future1 = supplyAsync(stringSupplier("Function 1", "Parent"));
             ContextAwareCompletableFuture<String> future2 = supplyAsync(stringSupplier("Function 2", "Parent"));
@@ -1189,7 +1189,7 @@ public class ContextAwareCompletableFutureTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void testAcceptEither(boolean takeNewSnapshot) {
-        try (Context<String> ctx = manager.initializeNewContext("Parent")) {
+        try (Context ctx = manager.initializeNewContext("Parent")) {
             // prepare
             ContextAwareCompletableFuture<String> future1 = supplyAsync(stringSupplier("Function 1", "Parent"));
             ContextAwareCompletableFuture<String> future2 = supplyAsync(stringSupplier("Function 2", "Parent"));
@@ -1208,7 +1208,7 @@ public class ContextAwareCompletableFutureTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void testAcceptEitherAsync(boolean takeNewSnapshot) {
-        try (Context<String> ctx = manager.initializeNewContext("Parent")) {
+        try (Context ctx = manager.initializeNewContext("Parent")) {
             // prepare
             ContextAwareCompletableFuture<String> future1 = supplyAsync(stringSupplier("Function 1", "Parent"));
             ContextAwareCompletableFuture<String> future2 = supplyAsync(stringSupplier("Function 2", "Parent"));
@@ -1227,7 +1227,7 @@ public class ContextAwareCompletableFutureTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void testAcceptEitherAsync_executor(boolean takeNewSnapshot) {
-        try (Context<String> ctx = manager.initializeNewContext("Parent")) {
+        try (Context ctx = manager.initializeNewContext("Parent")) {
             // prepare
             ContextAwareCompletableFuture<String> future1 = supplyAsync(stringSupplier("Function 1", "Parent"));
             ContextAwareCompletableFuture<String> future2 = supplyAsync(stringSupplier("Function 2", "Parent"));
@@ -1246,7 +1246,7 @@ public class ContextAwareCompletableFutureTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void testRunAfterEither(boolean takeNewSnapshot) {
-        try (Context<String> ctx = manager.initializeNewContext("Parent")) {
+        try (Context ctx = manager.initializeNewContext("Parent")) {
             // prepare
             ContextAwareCompletableFuture<String> future1 = supplyAsync(stringSupplier("Function 1", "Parent"));
             ContextAwareCompletableFuture<String> future2 = supplyAsync(stringSupplier("Function 2", "Parent"));
@@ -1262,7 +1262,7 @@ public class ContextAwareCompletableFutureTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void testRunAfterEitherAsync(boolean takeNewSnapshot) {
-        try (Context<String> ctx = manager.initializeNewContext("Parent")) {
+        try (Context ctx = manager.initializeNewContext("Parent")) {
             // prepare
             ContextAwareCompletableFuture<String> future1 = supplyAsync(stringSupplier("Function 1", "Parent"));
             ContextAwareCompletableFuture<String> future2 = supplyAsync(stringSupplier("Function 2", "Parent"));
@@ -1278,7 +1278,7 @@ public class ContextAwareCompletableFutureTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void testRunAfterEitherAsync_executor(boolean takeNewSnapshot) {
-        try (Context<String> ctx = manager.initializeNewContext("Parent")) {
+        try (Context ctx = manager.initializeNewContext("Parent")) {
             // prepare
             ContextAwareCompletableFuture<String> future1 = supplyAsync(stringSupplier("Function 1", "Parent"));
             ContextAwareCompletableFuture<String> future2 = supplyAsync(stringSupplier("Function 2", "Parent"));
@@ -1293,7 +1293,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenCompose() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("John")) {
+        try (Context ctx = manager.initializeNewContext("John")) {
             assertThat(supplyAsync(() -> {
                 String current = manager.getActiveContextValue();
                 DummyContext.setCurrentValue("Travolta");
@@ -1301,7 +1301,7 @@ public class ContextAwareCompletableFutureTest {
             }).thenCompose(value -> supplyAsync(() -> value + manager.getActiveContextValue())).get(), is("JohnJohn"));
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("John")) {
+        try (Context ctx = manager.initializeNewContext("John")) {
             assertThat(supplyAsync(() -> {
                 String current = manager.getActiveContextValue();
                 DummyContext.setCurrentValue("Travolta");
@@ -1312,7 +1312,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenComposeAsync() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("John")) {
+        try (Context ctx = manager.initializeNewContext("John")) {
             assertThat(supplyAsync(() -> {
                 String current = manager.getActiveContextValue();
                 DummyContext.setCurrentValue("Travolta");
@@ -1320,7 +1320,7 @@ public class ContextAwareCompletableFutureTest {
             }).thenComposeAsync(value -> supplyAsync(() -> value + manager.getActiveContextValue())).get(), is("JohnJohn"));
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("John")) {
+        try (Context ctx = manager.initializeNewContext("John")) {
             assertThat(supplyAsync(() -> {
                 String current = manager.getActiveContextValue();
                 DummyContext.setCurrentValue("Travolta");
@@ -1331,7 +1331,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testThenComposeAsync_executor() throws ExecutionException, InterruptedException {
-        try (Context<String> ctx = manager.initializeNewContext("John")) {
+        try (Context ctx = manager.initializeNewContext("John")) {
             assertThat(supplyAsync(() -> {
                 String current = manager.getActiveContextValue();
                 DummyContext.setCurrentValue("Travolta");
@@ -1339,7 +1339,7 @@ public class ContextAwareCompletableFutureTest {
             }).thenComposeAsync(value -> completedFuture(value + manager.getActiveContextValue()), contextUnawareThreadpool).get(), is("JohnJohn"));
         }
 
-        try (Context<String> ctx = manager.initializeNewContext("John")) {
+        try (Context ctx = manager.initializeNewContext("John")) {
             assertThat(supplyAsync(() -> {
                 String current = manager.getActiveContextValue();
                 DummyContext.setCurrentValue("Travolta");
@@ -1350,7 +1350,7 @@ public class ContextAwareCompletableFutureTest {
 
     @Test
     public void testTimingIssue55() throws ExecutionException, InterruptedException, TimeoutException {
-        try (Context<String> ctx = manager.initializeNewContext("Vincent Vega")) {
+        try (Context ctx = manager.initializeNewContext("Vincent Vega")) {
             final CountDownLatch latch1 = new CountDownLatch(1), latch2 = new CountDownLatch(1);
             ContextAwareCompletableFuture<String> future1 = supplyAsync(() -> {
                 String result = Optional.ofNullable(DummyContext.currentValue()).orElse("NO VALUE");

--- a/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/function/BiConsumerWithContextTest.java
+++ b/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/function/BiConsumerWithContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 public class BiConsumerWithContextTest {
     private ExecutorService unawareThreadpool;
     private ContextSnapshot snapshot;
-    private Context<Void> context;
+    private Context context;
 
     @BeforeEach
     @AfterEach

--- a/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/function/BiFunctionWithContextTest.java
+++ b/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/function/BiFunctionWithContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.when;
 public class BiFunctionWithContextTest {
 
     private ContextSnapshot snapshot;
-    private Context<Void> context;
+    private Context context;
 
     @BeforeEach
     @AfterEach

--- a/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/function/BiPredicateWithContextTest.java
+++ b/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/function/BiPredicateWithContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.when;
 public class BiPredicateWithContextTest {
 
     private ContextSnapshot snapshot;
-    private Context<Void> context;
+    private Context context;
 
     @BeforeEach
     @AfterEach

--- a/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/function/BinaryOperatorWithContextTest.java
+++ b/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/function/BinaryOperatorWithContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.when;
 public class BinaryOperatorWithContextTest {
 
     private ContextSnapshot snapshot;
-    private Context<Void> context;
+    private Context context;
 
     @BeforeEach
     @AfterEach

--- a/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/function/ConsumerWithContextTest.java
+++ b/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/function/ConsumerWithContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 public class ConsumerWithContextTest {
     private ExecutorService unawareThreadpool;
     private ContextSnapshot snapshot;
-    private Context<Void> context;
+    private Context context;
 
     @BeforeEach
     @AfterEach

--- a/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/function/FunctionWithContextTest.java
+++ b/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/function/FunctionWithContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.when;
 public class FunctionWithContextTest {
 
     private ContextSnapshot snapshot;
-    private Context<Void> context;
+    private Context context;
 
     @BeforeEach
     @AfterEach

--- a/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/function/PredicateWithContextTest.java
+++ b/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/function/PredicateWithContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.when;
 public class PredicateWithContextTest {
 
     private ContextSnapshot snapshot;
-    private Context<Void> context;
+    private Context context;
 
     @BeforeEach
     @AfterEach

--- a/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/function/RunnableWithContextTest.java
+++ b/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/function/RunnableWithContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.when;
 public class RunnableWithContextTest {
 
     private ContextSnapshot snapshot;
-    private Context<Void> context;
+    private Context context;
 
     @BeforeEach
     @AfterEach

--- a/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/function/SupplierWithContextTest.java
+++ b/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/function/SupplierWithContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ public class SupplierWithContextTest {
 
     private ExecutorService unawareThreadpool;
     private ContextSnapshot snapshot;
-    private Context<Void> context;
+    private Context context;
 
     @BeforeEach
     @AfterEach

--- a/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/function/UnaryOperatorWithContextTest.java
+++ b/context-propagation-core/src/test/java/nl/talsmasoftware/context/core/function/UnaryOperatorWithContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.when;
 public class UnaryOperatorWithContextTest {
 
     private ContextSnapshot snapshot;
-    private Context<Void> context;
+    private Context context;
 
     @BeforeEach
     @AfterEach

--- a/context-propagation-core/src/test/java/nl/talsmasoftware/context/dummy/DummyContextManager.java
+++ b/context-propagation-core/src/test/java/nl/talsmasoftware/context/dummy/DummyContextManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import nl.talsmasoftware.context.api.ContextManager;
  */
 public class DummyContextManager implements ContextManager<String> {
 
-    public Context<String> initializeNewContext(String value) {
+    public Context initializeNewContext(String value) {
         return new DummyContext(value);
     }
 

--- a/context-propagation-core/src/test/java/nl/talsmasoftware/context/dummy/ThrowingContextManager.java
+++ b/context-propagation-core/src/test/java/nl/talsmasoftware/context/dummy/ThrowingContextManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ public class ThrowingContextManager implements ContextManager<String> {
     }
 
     @Override
-    public Context<String> initializeNewContext(String value) {
+    public Context initializeNewContext(String value) {
         if (onInitialize != null) try {
             throw onInitialize;
         } finally {

--- a/managers/context-manager-locale/src/main/java/nl/talsmasoftware/context/managers/locale/CurrentLocaleHolder.java
+++ b/managers/context-manager-locale/src/main/java/nl/talsmasoftware/context/managers/locale/CurrentLocaleHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ import java.util.logging.Logger;
  *
  * @author Sjoerd Talsma
  */
-public final class CurrentLocaleHolder implements Context<Locale> {
+public final class CurrentLocaleHolder implements Context {
     private static final Logger LOGGER = Logger.getLogger(CurrentLocaleHolder.class.getName());
 
     /**
@@ -101,7 +101,7 @@ public final class CurrentLocaleHolder implements Context<Locale> {
      * @param locale The locale to become the current locale.
      * @return The context to restore the previous locale upon {@code close()}.
      */
-    public static Context<Locale> set(Locale locale) {
+    public static Context set(Locale locale) {
         CurrentLocaleHolder newHolder = new CurrentLocaleHolder(LOCALE.get(), locale);
         LOCALE.set(newHolder);
         return newHolder;

--- a/managers/context-manager-locale/src/main/java/nl/talsmasoftware/context/managers/locale/CurrentLocaleManager.java
+++ b/managers/context-manager-locale/src/main/java/nl/talsmasoftware/context/managers/locale/CurrentLocaleManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ public final class CurrentLocaleManager implements ContextManager<Locale> {
      * @return The context to be closed again by the caller to remove this locale as current locale.
      * @see CurrentLocaleHolder#set(Locale)
      */
-    public Context<Locale> initializeNewContext(Locale value) {
+    public Context initializeNewContext(Locale value) {
         return CurrentLocaleHolder.set(value);
     }
 

--- a/managers/context-manager-locale/src/test/java/nl/talsmasoftware/context/managers/locale/CurrentLocaleHolderTest.java
+++ b/managers/context-manager-locale/src/test/java/nl/talsmasoftware/context/managers/locale/CurrentLocaleHolderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,11 +50,11 @@ class CurrentLocaleHolderTest {
     @Test
     void outOfSequenceClosingMustBeSupported() {
         // ctx1 = GERMAN
-        Context<Locale> ctx1 = CurrentLocaleHolder.set(Locale.GERMAN);
+        Context ctx1 = CurrentLocaleHolder.set(Locale.GERMAN);
         assertThat(CurrentLocaleHolder.getOrDefault()).isEqualTo(Locale.GERMAN);
 
         // ctx2 = ENGLISH
-        Context<Locale> ctx2 = CurrentLocaleHolder.set(Locale.ENGLISH);
+        Context ctx2 = CurrentLocaleHolder.set(Locale.ENGLISH);
         assertThat(CurrentLocaleHolder.getOrDefault()).isEqualTo(Locale.ENGLISH);
 
         // out-of-sequence, ctx1 is closed first.
@@ -68,13 +68,13 @@ class CurrentLocaleHolderTest {
 
     @Test
     void testToString_current() {
-        Context<Locale> currentContext = CurrentLocaleHolder.set(Locale.ENGLISH);
+        Context currentContext = CurrentLocaleHolder.set(Locale.ENGLISH);
         assertThat(currentContext).hasToString("CurrentLocaleHolder{en}");
     }
 
     @Test
     void testToString_closed() {
-        Context<Locale> closedContext = CurrentLocaleHolder.set(Locale.ENGLISH);
+        Context closedContext = CurrentLocaleHolder.set(Locale.ENGLISH);
         closedContext.close();
 
         assertThat(closedContext).hasToString("CurrentLocaleHolder{closed}");
@@ -82,7 +82,7 @@ class CurrentLocaleHolderTest {
 
     @Test
     void testClose_mustBeRepeatable() {
-        Context<Locale> context = CurrentLocaleHolder.set(Locale.ENGLISH);
+        Context context = CurrentLocaleHolder.set(Locale.ENGLISH);
         assertDoesNotThrow(context::close);
         assertDoesNotThrow(context::close);
         assertDoesNotThrow(context::close);

--- a/managers/context-manager-locale/src/test/java/nl/talsmasoftware/context/managers/locale/CurrentLocaleManagerTest.java
+++ b/managers/context-manager-locale/src/test/java/nl/talsmasoftware/context/managers/locale/CurrentLocaleManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,13 +63,13 @@ public class CurrentLocaleManagerTest {
 
     @Test
     public void testLocalePropagation() throws ExecutionException, InterruptedException {
-        try (Context<Locale> ctx1 = CurrentLocaleHolder.set(DUTCH)) {
+        try (Context ctx1 = CurrentLocaleHolder.set(DUTCH)) {
             assertThat(MANAGER.getActiveContextValue(), is(DUTCH));
             assertThat(CurrentLocaleHolder.getOrDefault(), is(DUTCH));
 
             final CountDownLatch blocker = new CountDownLatch(1);
             Future<Locale> slowCall;
-            try (Context<Locale> ctx2 = MANAGER.initializeNewContext(GERMAN)) {
+            try (Context ctx2 = MANAGER.initializeNewContext(GERMAN)) {
                 assertThat(MANAGER.getActiveContextValue(), is(GERMAN));
                 assertThat(CurrentLocaleHolder.getOrDefault(), is(GERMAN));
 
@@ -91,11 +91,11 @@ public class CurrentLocaleManagerTest {
     @Test
     public void testGetCurrentLocaleOrDefault() {
         assertThat(CurrentLocaleHolder.getOrDefault(), is(DEFAULT_LOCALE));
-        try (Context<Locale> ctx1 = CurrentLocaleHolder.set(GERMAN)) {
+        try (Context ctx1 = CurrentLocaleHolder.set(GERMAN)) {
             assertThat(CurrentLocaleHolder.getOrDefault(), is(GERMAN));
             assertThat(MANAGER.getActiveContextValue(), is(GERMAN));
 
-            try (Context<Locale> ctx2 = MANAGER.initializeNewContext(null)) {
+            try (Context ctx2 = MANAGER.initializeNewContext(null)) {
                 assertThat(CurrentLocaleHolder.getOrDefault(), is(DEFAULT_LOCALE));
                 assertThat(MANAGER.getActiveContextValue(), nullValue());
             } finally {

--- a/managers/context-manager-log4j2/src/main/java/nl/talsmasoftware/context/managers/log4j2/threadcontext/Log4j2ThreadContextManager.java
+++ b/managers/context-manager-log4j2/src/main/java/nl/talsmasoftware/context/managers/log4j2/threadcontext/Log4j2ThreadContextManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,7 +109,7 @@ public class Log4j2ThreadContextManager implements ContextManager<Log4j2ThreadCo
      * @return The new <em>active</em> context containing the specified value
      * which should be closed by the caller at the end of its lifecycle from the same thread.
      */
-    public Context<Log4j2ThreadContextSnapshot> initializeNewContext(final Log4j2ThreadContextSnapshot value) {
+    public Context initializeNewContext(final Log4j2ThreadContextSnapshot value) {
         if (value == null) {
             throw new NullPointerException("value must not be null");
         }
@@ -132,7 +132,7 @@ public class Log4j2ThreadContextManager implements ContextManager<Log4j2ThreadCo
         return getClass().getSimpleName();
     }
 
-    private static final class ManagedLog4j2ThreadContext implements Context<Log4j2ThreadContextSnapshot> {
+    private static final class ManagedLog4j2ThreadContext implements Context {
         private final Log4j2ThreadContextSnapshot previous, value;
         private final AtomicBoolean closed;
 

--- a/managers/context-manager-log4j2/src/test/java/nl/talsmasoftware/context/managers/log4j2/threadcontext/Log4j2ThreadContextManagerTest.java
+++ b/managers/context-manager-log4j2/src/test/java/nl/talsmasoftware/context/managers/log4j2/threadcontext/Log4j2ThreadContextManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -221,7 +221,7 @@ class Log4j2ThreadContextManagerTest {
 
         final Log4j2ThreadContextManager mgr = Log4j2ThreadContextManager.provider();
 
-        Context<Log4j2ThreadContextSnapshot> ctx = mgr.initializeNewContext(data);
+        Context ctx = mgr.initializeNewContext(data);
         try {
             assertThat(ctx, hasToString("ManagedLog4j2ThreadContext{" + data + "}"));
         } finally {

--- a/managers/context-manager-opentelemetry/src/main/java/nl/talsmasoftware/context/managers/opentelemetry/OpenTelemetryContextManager.java
+++ b/managers/context-manager-opentelemetry/src/main/java/nl/talsmasoftware/context/managers/opentelemetry/OpenTelemetryContextManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,8 +82,8 @@ public class OpenTelemetryContextManager implements ContextManager<io.openteleme
      * @see io.opentelemetry.context.Context#makeCurrent()
      */
     @Override
-    public Context<io.opentelemetry.context.Context> initializeNewContext(final io.opentelemetry.context.Context value) {
-        return new ScopeWrappingContext<>(value.makeCurrent());
+    public Context initializeNewContext(final io.opentelemetry.context.Context value) {
+        return new ScopeWrappingContext(value.makeCurrent());
     }
 
     /**

--- a/managers/context-manager-opentelemetry/src/main/java/nl/talsmasoftware/context/managers/opentelemetry/ScopeWrappingContext.java
+++ b/managers/context-manager-opentelemetry/src/main/java/nl/talsmasoftware/context/managers/opentelemetry/ScopeWrappingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,8 @@ import nl.talsmasoftware.context.api.Context;
 
 /**
  * Context wrapping an {@linkplain Scope OpenTelemetry Scope}, closing it when the context is closed.
- *
- * @param <T> The type of the contained value, left for the subclass to provide.
  */
-class ScopeWrappingContext<T> implements Context<T> {
+class ScopeWrappingContext implements Context {
     private final Scope scope;
 
     /**

--- a/managers/context-manager-opentelemetry/src/test/java/nl/talsmasoftware/context/managers/opentelemetry/OpenTelemetryContextManagerTest.java
+++ b/managers/context-manager-opentelemetry/src/test/java/nl/talsmasoftware/context/managers/opentelemetry/OpenTelemetryContextManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ class OpenTelemetryContextManagerTest {
         assertThat(Context.current().get(dummyKey)).isNull();
 
         // execute
-        try (nl.talsmasoftware.context.api.Context<Context> context = subject.initializeNewContext(newContext)) {
+        try (nl.talsmasoftware.context.api.Context context = subject.initializeNewContext(newContext)) {
 
             // verify
             assertThat(Context.current().get(dummyKey)).isEqualTo(dummyValue);

--- a/managers/context-manager-opentracing/src/main/java/nl/talsmasoftware/context/managers/opentracing/ContextScopeManager.java
+++ b/managers/context-manager-opentracing/src/main/java/nl/talsmasoftware/context/managers/opentracing/ContextScopeManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,8 +112,8 @@ public class ContextScopeManager implements ScopeManager, ContextManager<Span> {
      */
     @Override
     @SuppressWarnings("unchecked")
-    public Context<Span> initializeNewContext(Span value) {
-        return (Context<Span>) activate(value);
+    public Context initializeNewContext(Span value) {
+        return (Context) activate(value);
     }
 
     /**

--- a/managers/context-manager-opentracing/src/main/java/nl/talsmasoftware/context/managers/opentracing/SpanManager.java
+++ b/managers/context-manager-opentracing/src/main/java/nl/talsmasoftware/context/managers/opentracing/SpanManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,7 +103,7 @@ public class SpanManager implements ContextManager<Span> {
      * @return The new context that <strong>must</strong> be closed.
      */
     @Override
-    public Context<Span> initializeNewContext(final Span span) {
+    public Context initializeNewContext(final Span span) {
         return new SpanContext(span);
     }
 
@@ -125,7 +125,7 @@ public class SpanManager implements ContextManager<Span> {
         return GlobalTracer.get().activeSpan();
     }
 
-    private static class SpanContext implements Context<Span> {
+    private static class SpanContext implements Context {
         private final AtomicBoolean closed = new AtomicBoolean(false);
         private final Scope scope;
 

--- a/managers/context-manager-opentracing/src/test/java/nl/talsmasoftware/context/managers/opentracing/ContextScopeManagerTest.java
+++ b/managers/context-manager-opentracing/src/test/java/nl/talsmasoftware/context/managers/opentracing/ContextScopeManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,9 +84,6 @@ public class ContextScopeManagerTest {
                 }
             });
         }
-//        assertThat(ContextScopeManagerObserver.observed, contains(
-//                activated(withOperationName("parent"))
-//        ));
 
         assertThat(GlobalTracer.get().activeSpan(), equalTo(parentSpan));
         for (Thread t : threads) t.start();
@@ -94,36 +91,12 @@ public class ContextScopeManagerTest {
         parentSpan.finish();
         parent.close();
         assertThat(GlobalTracer.get().activeSpan(), is(nullValue()));
-//        assertThat(ContextScopeManagerObserver.observed, contains(
-//                activated(withOperationName("parent")),
-//                activated(withOperationName(startsWith("inner"))),
-//                activated(withOperationName(startsWith("inner"))),
-//                activated(withOperationName(startsWith("inner"))),
-//                activated(withOperationName(startsWith("inner"))),
-//                activated(withOperationName(startsWith("inner"))),
-//                activated(withOperationName(startsWith("inner"))),
-//                activated(withOperationName(startsWith("inner"))),
-//                activated(withOperationName(startsWith("inner"))),
-//                activated(withOperationName(startsWith("inner"))),
-//                activated(withOperationName(startsWith("inner"))),
-//                deactivated(withOperationName(startsWith("inner"))),
-//                deactivated(withOperationName(startsWith("inner"))),
-//                deactivated(withOperationName(startsWith("inner"))),
-//                deactivated(withOperationName(startsWith("inner"))),
-//                deactivated(withOperationName(startsWith("inner"))),
-//                deactivated(withOperationName(startsWith("inner"))),
-//                deactivated(withOperationName(startsWith("inner"))),
-//                deactivated(withOperationName(startsWith("inner"))),
-//                deactivated(withOperationName(startsWith("inner"))),
-//                deactivated(withOperationName(startsWith("inner"))),
-//                deactivated(withOperationName("parent"))
-//        ));
     }
 
     @Test
     public void testInitializeNewContext() {
         Span span = GlobalTracer.get().buildSpan("span").start();
-        Context<Span> context = scopeManager.initializeNewContext(span);
+        Context context = scopeManager.initializeNewContext(span);
         assertThat(scopeManager.getActiveContextValue(), is(span));
         assertThat(scopeManager.activeSpan(), is(span));
         assertThat(GlobalTracer.get().activeSpan(), is(span));

--- a/managers/context-manager-servletrequest/src/main/java/nl/talsmasoftware/context/managers/servletrequest/ServletRequestContext.java
+++ b/managers/context-manager-servletrequest/src/main/java/nl/talsmasoftware/context/managers/servletrequest/ServletRequestContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * @author Sjoerd Talsma
  */
-final class ServletRequestContext implements Context<ServletRequest> {
+final class ServletRequestContext implements Context {
     private static final ThreadLocal<ServletRequestContext> CONTEXT = new ThreadLocal<>();
     final ServletRequestContext previous;
     final ServletRequest value;

--- a/managers/context-manager-servletrequest/src/main/java/nl/talsmasoftware/context/managers/servletrequest/ServletRequestContextFilter.java
+++ b/managers/context-manager-servletrequest/src/main/java/nl/talsmasoftware/context/managers/servletrequest/ServletRequestContextFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ public class ServletRequestContextFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
         // Automatically becomes the new active context.
-        try (Context<ServletRequest> context = MANAGER.initializeNewContext(request)) {
+        try (Context context = MANAGER.initializeNewContext(request)) {
 
             if (request.isAsyncStarted()) try {
                 request.getAsyncContext().addListener(new ServletRequestContextAsyncListener());

--- a/managers/context-manager-servletrequest/src/main/java/nl/talsmasoftware/context/managers/servletrequest/ServletRequestContextManager.java
+++ b/managers/context-manager-servletrequest/src/main/java/nl/talsmasoftware/context/managers/servletrequest/ServletRequestContextManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ public final class ServletRequestContextManager implements ContextManager<Servle
      * @return The context for the given servlet request.
      * The context <strong>must be</strong> closed in the same that initialized it.
      */
-    public Context<ServletRequest> initializeNewContext(ServletRequest servletRequest) {
+    public Context initializeNewContext(ServletRequest servletRequest) {
         return new ServletRequestContext(servletRequest);
     }
 

--- a/managers/context-manager-servletrequest/src/test/java/nl/talsmasoftware/context/managers/servletrequest/ServletRequestContextManagerTest.java
+++ b/managers/context-manager-servletrequest/src/test/java/nl/talsmasoftware/context/managers/servletrequest/ServletRequestContextManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ public class ServletRequestContextManagerTest {
         assertThat(ServletRequestContextManager.provider().getActiveContextValue(), is(nullValue()));
 
         final ServletRequest request = mock(ServletRequest.class);
-        Context<ServletRequest> ctx = ServletRequestContextManager.provider().initializeNewContext(request);
+        Context ctx = ServletRequestContextManager.provider().initializeNewContext(request);
 
         assertThat(ServletRequestContextManager.provider().getActiveContextValue(), is(sameInstance(request)));
         ctx.close();
@@ -77,7 +77,7 @@ public class ServletRequestContextManagerTest {
         assertThat(ServletRequestContextManager.currentServletRequest(), is(nullValue()));
 
         final ServletRequest request = mock(ServletRequest.class);
-        Context<ServletRequest> ctx = ServletRequestContextManager.provider().initializeNewContext(request);
+        Context ctx = ServletRequestContextManager.provider().initializeNewContext(request);
 
         assertThat(ServletRequestContextManager.currentServletRequest(), is(sameInstance(request)));
         ctx.close();
@@ -87,7 +87,7 @@ public class ServletRequestContextManagerTest {
     @Test
     public void testClearableImplementation() {
         final ServletRequest request = mock(ServletRequest.class);
-        Context<ServletRequest> ctx = ServletRequestContextManager.provider().initializeNewContext(request);
+        Context ctx = ServletRequestContextManager.provider().initializeNewContext(request);
         assertThat(ServletRequestContextManager.provider().getActiveContextValue(), is(sameInstance(request)));
 
         ContextManager.clearAll();
@@ -100,13 +100,13 @@ public class ServletRequestContextManagerTest {
         ServletRequest request1 = mock(ServletRequest.class);
         ServletRequest request2 = mock(ServletRequest.class);
 
-        try (Context<ServletRequest> ctx1 = manager.initializeNewContext(request1)) {
+        try (Context ctx1 = manager.initializeNewContext(request1)) {
             assertThat("Current context", manager.getActiveContextValue(), is(notNullValue()));
             assertThat("Current context value", manager.getActiveContextValue(), is(request1));
 
             final CountDownLatch blocker = new CountDownLatch(1);
             Future<ServletRequest> slowCall;
-            try (Context<ServletRequest> ctx2 = manager.initializeNewContext(request2)) {
+            try (Context ctx2 = manager.initializeNewContext(request2)) {
                 slowCall = threadpool.submit(new Callable<ServletRequest>() {
                     public ServletRequest call() throws InterruptedException {
                         blocker.await(5, TimeUnit.SECONDS);
@@ -130,7 +130,7 @@ public class ServletRequestContextManagerTest {
         assertThat(manager.getActiveContextValue(), nullValue());
 
         ServletRequest request = mock(ServletRequest.class);
-        Context<ServletRequest> servletRequestContext = manager.initializeNewContext(request);
+        Context servletRequestContext = manager.initializeNewContext(request);
         assertThat(servletRequestContext, hasToString("ServletRequestContext{value=" + request + "}"));
 
         servletRequestContext.close();

--- a/managers/context-manager-slf4j/src/main/java/nl/talsmasoftware/context/managers/slf4j/mdc/Slf4jMdcManager.java
+++ b/managers/context-manager-slf4j/src/main/java/nl/talsmasoftware/context/managers/slf4j/mdc/Slf4jMdcManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ public class Slf4jMdcManager implements ContextManager<Map<String, String>> {
      *                  (which must be closed by the caller at the end of its lifecycle).
      * @return A context that -when closed- will restore the active MDC values to what they were just before this call.
      */
-    public Context<Map<String, String>> initializeNewContext(final Map<String, String> mdcValues) {
+    public Context initializeNewContext(final Map<String, String> mdcValues) {
         return new Slf4jMdcContext(mdcValues);
     }
 
@@ -122,7 +122,7 @@ public class Slf4jMdcManager implements ContextManager<Map<String, String>> {
         return getClass().getSimpleName();
     }
 
-    private static final class Slf4jMdcContext implements Context<Map<String, String>> {
+    private static final class Slf4jMdcContext implements Context {
         private final Map<String, String> previous;
         private final AtomicBoolean closed;
 

--- a/managers/context-manager-slf4j/src/test/java/nl/talsmasoftware/context/managers/slf4j/mdc/Slf4jMdcManagerTest.java
+++ b/managers/context-manager-slf4j/src/test/java/nl/talsmasoftware/context/managers/slf4j/mdc/Slf4jMdcManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,7 +104,7 @@ public class Slf4jMdcManagerTest {
         Map<String, String> mdc = MDC.getCopyOfContextMap();
         assertThat(mgr.getActiveContextValue(), equalTo(mdc));
 
-        try (Context<Map<String, String>> ctx = mgr.initializeNewContext(mdc)) {
+        try (Context ctx = mgr.initializeNewContext(mdc)) {
             assertThat(ctx, hasToString("Slf4jMdcContext" + mdc));
         }
     }

--- a/managers/context-manager-spring-security/src/main/java/nl/talsmasoftware/context/managers/spring/security/SpringSecurityContextManager.java
+++ b/managers/context-manager-spring-security/src/main/java/nl/talsmasoftware/context/managers/spring/security/SpringSecurityContextManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ public class SpringSecurityContextManager implements ContextManager<Authenticati
      * @param authentication The value to initialize a new context for.
      * @return A context with the new Authentication, restoring the previous authentication when closed.
      */
-    public Context<Authentication> initializeNewContext(Authentication authentication) {
+    public Context initializeNewContext(Authentication authentication) {
         return new AuthenticationContext(authentication);
     }
 
@@ -97,7 +97,7 @@ public class SpringSecurityContextManager implements ContextManager<Authenticati
         SecurityContextHolder.clearContext();
     }
 
-    private static final class AuthenticationContext implements Context<Authentication> {
+    private static final class AuthenticationContext implements Context {
         private final SecurityContext previous;
         private final AtomicBoolean closed;
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <packaging>pom</packaging>
 
     <!-- Project information -->
-    <name>Context propagation (root)</name>
+    <name>Context propagation</name>
     <description>Standardized context propagation in concurrent systems.</description>
     <url>https://github.com/talsma-ict/context-propagation</url>
     <inceptionYear>2016</inceptionYear>
@@ -139,7 +139,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <systemPropertyVariables>
-                        <java.util.logging.config.file>${project.build.testOutputDirectory}/logging.properties</java.util.logging.config.file>
+                        <java.util.logging.config.file>${project.build.testOutputDirectory}/logging.properties
+                        </java.util.logging.config.file>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -242,11 +243,15 @@
                         </offlineLink>
                         <offlineLink>
                             <location>${root.basedir}/.mvn/javadoc/opentelemetry-api</location>
-                            <url>https://www.javadoc.io/page/io.opentelemetry/opentelemetry-api/${opentelemetry.version}</url>
+                            <url>
+                                https://www.javadoc.io/page/io.opentelemetry/opentelemetry-api/${opentelemetry.version}
+                            </url>
                         </offlineLink>
                         <offlineLink>
                             <location>${root.basedir}/.mvn/javadoc/opentelemetry-context</location>
-                            <url>https://www.javadoc.io/page/io.opentelemetry/opentelemetry-context/${opentelemetry.version}</url>
+                            <url>
+                                https://www.javadoc.io/page/io.opentelemetry/opentelemetry-context/${opentelemetry.version}
+                            </url>
                         </offlineLink>
                         <offlineLink>
                             <location>${root.basedir}/.mvn/javadoc/opentracing-api</location>
@@ -254,7 +259,8 @@
                         </offlineLink>
                         <offlineLink>
                             <location>${root.basedir}/.mvn/javadoc/opentracing-util</location>
-                            <url>https://javadoc.io/page/io.opentracing/opentracing-util/${opentracing-api.version}</url>
+                            <url>https://javadoc.io/page/io.opentracing/opentracing-util/${opentracing-api.version}
+                            </url>
                         </offlineLink>
                         <offlineLink>
                             <location>${root.basedir}/.mvn/javadoc/servlet-api</location>
@@ -266,7 +272,9 @@
                         </offlineLink>
                         <offlineLink>
                             <location>${root.basedir}/.mvn/javadoc/spring-security-core</location>
-                            <url>https://javadoc.io/page/org.springframework.security/spring-security-core/${spring-security.version}</url>
+                            <url>
+                                https://javadoc.io/page/org.springframework.security/spring-security-core/${spring-security.version}
+                            </url>
                         </offlineLink>
                     </offlineLinks>
                 </configuration>


### PR DESCRIPTION
The generic type parameter `<T>` for the Context class has become unnecessary in the new API and is removed.