### PR TITLE
Add gRPC ContextManager implementation.

### DIFF
--- a/managers/context-manager-grpc/pom.xml
+++ b/managers/context-manager-grpc/pom.xml
@@ -50,27 +50,7 @@
             <groupId>io.grpc</groupId>
             <artifactId>grpc-api</artifactId>
         </dependency>
-<!--
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-context</artifactId>
-        </dependency>
--->
-<!--
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-opentelemetry</artifactId>
-        </dependency>
--->
 
-<!--
-        <dependency>
-            <groupId>${project.parent.groupId}</groupId>
-            <artifactId>context-propagation-core</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
--->
         <dependency>
             <groupId>nl.talsmasoftware.context.managers</groupId>
             <artifactId>context-manager-locale</artifactId>

--- a/managers/context-manager-grpc/pom.xml
+++ b/managers/context-manager-grpc/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2025 Talsma ICT
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>nl.talsmasoftware.context</groupId>
+        <artifactId>context-propagation</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <!-- Artifact identification -->
+    <groupId>nl.talsmasoftware.context.managers</groupId>
+    <artifactId>context-manager-grpc</artifactId>
+    <name>Propagation of gRPC Context</name>
+    <packaging>jar</packaging>
+
+    <properties>
+        <project.moduleName>${project.groupId}.grpc</project.moduleName>
+        <root.basedir>${project.parent.basedir}</root.basedir>
+
+        <grpc.version>1.73.0</grpc.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>context-propagation-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-api</artifactId>
+        </dependency>
+<!--
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-context</artifactId>
+        </dependency>
+-->
+<!--
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-opentelemetry</artifactId>
+        </dependency>
+-->
+
+<!--
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>context-propagation-core</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+-->
+        <dependency>
+            <groupId>nl.talsmasoftware.context.managers</groupId>
+            <artifactId>context-manager-locale</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-bom</artifactId>
+                <version>${grpc.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/managers/context-manager-grpc/src/main/java/io/grpc/override/ContextStorageOverride.java
+++ b/managers/context-manager-grpc/src/main/java/io/grpc/override/ContextStorageOverride.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016-2025 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.grpc.override;
+
+import io.grpc.Context;
+import nl.talsmasoftware.context.managers.grpc.GrpcContextManager;
+
+public class ContextStorageOverride extends Context.Storage {
+    @Override
+    public Context doAttach(Context toAttach) {
+        return GrpcContextManager.provider().doAttach(toAttach);
+    }
+
+    @Override
+    public void detach(Context toDetach, Context toRestore) {
+        GrpcContextManager.provider().detach(toDetach, toRestore);
+    }
+
+    @Override
+    public Context current() {
+        return GrpcContextManager.provider().current();
+    }
+}

--- a/managers/context-manager-grpc/src/main/java/nl/talsmasoftware/context/managers/grpc/GrpcContextManager.java
+++ b/managers/context-manager-grpc/src/main/java/nl/talsmasoftware/context/managers/grpc/GrpcContextManager.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2016-2025 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.context.managers.grpc;
+
+import io.grpc.Context.Key;
+import nl.talsmasoftware.context.api.Context;
+import nl.talsmasoftware.context.api.ContextManager;
+import nl.talsmasoftware.context.api.ContextSnapshot;
+
+import java.util.logging.Logger;
+
+import static io.grpc.Context.ROOT;
+import static io.grpc.Context.key;
+
+public class GrpcContextManager extends io.grpc.Context.Storage implements ContextManager<io.grpc.Context> {
+    private static final GrpcContextManager INSTANCE = new GrpcContextManager();
+    private static final Key<ContextSnapshot> GRPC_SNAPSHOT_KEY = key("contextsnapshot-over-grpc");
+    private static final Key<ContextSnapshot.Reactivation> GRPC_REACTIVATION_KEY = key("contextsnapshot-reactivation");
+    private static final Logger LOGGER = Logger.getLogger(GrpcContextManager.class.getName());
+    private static final ThreadLocal<io.grpc.Context> STORAGE = new ThreadLocal<io.grpc.Context>() {
+        @Override
+        public void set(io.grpc.Context value) {
+            if (ROOT.equals(value)) { // prevent ROOT from being set
+                value = null;
+            }
+            if (value != null) {
+                // do not store ContextSnapshot or its reactivation in the threadlocal!
+                if (GRPC_SNAPSHOT_KEY.get(value) != null) {
+                    value = value.withValue(GRPC_SNAPSHOT_KEY, null);
+                }
+                if (GRPC_REACTIVATION_KEY.get(value) != null) {
+                    value = value.withValue(GRPC_REACTIVATION_KEY, null);
+                }
+            }
+            super.set(value);
+        }
+    };
+
+    public GrpcContextManager() {
+        // legacy constructor for java8 ServiceLoader.
+    }
+
+    public static GrpcContextManager provider() {
+        return INSTANCE;
+    }
+
+    @Override
+    public io.grpc.Context getActiveContextValue() {
+        return STORAGE.get();
+    }
+
+    @Override
+    public io.grpc.Context current() {
+        io.grpc.Context current = getActiveContextValue();
+        return (current == null ? ROOT : current).withValue(GRPC_SNAPSHOT_KEY, ContextSnapshot.capture());
+    }
+
+    @Override
+    public Context activate(io.grpc.Context value) {
+        io.grpc.Context previous = STORAGE.get();
+        STORAGE.set(value);
+        return () -> STORAGE.set(previous);
+    }
+
+    @Override
+    public io.grpc.Context doAttach(io.grpc.Context toAttach) {
+        io.grpc.Context toRestore = STORAGE.get();
+        if (toRestore == null) {
+            toRestore = ROOT;
+        }
+        STORAGE.set(toAttach);
+        ContextSnapshot snapshot = toAttach == null ? null : GRPC_SNAPSHOT_KEY.get(toAttach);
+        if (snapshot == null) {
+            LOGGER.warning(() -> "No context snapshot found in gRPC context to be attached: " + toAttach);
+            return toRestore;
+        } else {
+            return toRestore.withValue(GRPC_REACTIVATION_KEY, snapshot.reactivate());
+        }
+    }
+
+    @Override
+    public void detach(io.grpc.Context toDetach, io.grpc.Context toRestore) {
+        ContextSnapshot.Reactivation reactivation = GRPC_REACTIVATION_KEY.get(toRestore);
+        if (reactivation == null) {
+            // should this ever happen?
+            LOGGER.warning(() -> "No snapshot reactivation present in gRPC context to be restored: " + toRestore);
+        } else {
+            reactivation.close();
+        }
+        STORAGE.set(toRestore);
+    }
+
+    @Override
+    public void clear() {
+        STORAGE.remove();
+    }
+
+}

--- a/managers/context-manager-grpc/src/main/resources/META-INF/services/nl.talsmasoftware.context.api.ContextManager
+++ b/managers/context-manager-grpc/src/main/resources/META-INF/services/nl.talsmasoftware.context.api.ContextManager
@@ -1,0 +1,1 @@
+nl.talsmasoftware.context.managers.grpc.GrpcContextManager

--- a/managers/context-manager-grpc/src/test/java/nl/talsmasoftware/context/managers/grpc/GrpcContextManagerTest.java
+++ b/managers/context-manager-grpc/src/test/java/nl/talsmasoftware/context/managers/grpc/GrpcContextManagerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2016-2025 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.context.managers.grpc;
+
+import io.grpc.Context;
+import nl.talsmasoftware.context.api.ContextManager;
+import nl.talsmasoftware.context.api.ContextSnapshot;
+import nl.talsmasoftware.context.managers.locale.CurrentLocaleHolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.OPTIONAL;
+
+class GrpcContextManagerTest {
+    static final Context.Key<String> TEST_KEY = Context.key("test-key");
+    static final Locale DUTCH = new Locale("nl", "NL");
+    static final ExecutorService THREAD_POOL = Executors.newCachedThreadPool();
+
+    @BeforeEach
+    @AfterEach
+    void clearAllContexts() {
+        ContextManager.clearAll();
+    }
+
+    @Test
+    void grpcContextIsPropagatedToBackgroundThread() {
+        String testValue = "test-" + UUID.randomUUID();
+        Context context = Context.current().withValue(TEST_KEY, testValue).attach();
+        try {
+
+            assertThat(THREAD_POOL.submit(() -> TEST_KEY.get()))
+                    .as("Test value from gRPC context in plain thread")
+                    .succeedsWithin(1, TimeUnit.SECONDS)
+                    .isNull();
+
+            ContextSnapshot snapshot = ContextSnapshot.capture();
+            assertThat(THREAD_POOL.submit(snapshot.wrap(() -> TEST_KEY.get())))
+                    .as("Test value from gRPC context in thread with snapshot")
+                    .succeedsWithin(1, TimeUnit.SECONDS)
+                    .isEqualTo(testValue);
+
+        } finally {
+            context.detach(Context.current());
+        }
+    }
+
+    @Test
+    void contextManagersArePropagatedWithGrpcContexg() {
+        CurrentLocaleHolder.set(DUTCH);
+
+        assertThat(THREAD_POOL.submit(CurrentLocaleHolder::get))
+                .as("Current Locale in plain thread")
+                .succeedsWithin(1, TimeUnit.SECONDS)
+                .asInstanceOf(OPTIONAL)
+                .isEmpty();
+
+        assertThat(THREAD_POOL.submit(Context.current().wrap(CurrentLocaleHolder::get)))
+                .as("Current Locale in thread with gRPC context")
+                .succeedsWithin(1, TimeUnit.SECONDS)
+                .asInstanceOf(OPTIONAL)
+                .contains(DUTCH);
+
+        assertThat(THREAD_POOL.submit(Context.ROOT.wrap(CurrentLocaleHolder::get)))
+                .as("Current Locale in plain thread")
+                .succeedsWithin(1, TimeUnit.SECONDS)
+                .asInstanceOf(OPTIONAL)
+                .isEmpty();
+
+    }
+
+}

--- a/managers/context-manager-grpc/src/test/java/nl/talsmasoftware/context/managers/grpc/GrpcContextManagerTest.java
+++ b/managers/context-manager-grpc/src/test/java/nl/talsmasoftware/context/managers/grpc/GrpcContextManagerTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.OPTIONAL;
 
 class GrpcContextManagerTest {
     static final Context.Key<String> TEST_KEY = Context.key("test-key");
-    static final Locale DUTCH = new Locale("nl", "NL");
+    static final Locale DUTCH = Locale.of("nl", "NL");
     static final ExecutorService THREAD_POOL = Executors.newCachedThreadPool();
 
     @BeforeEach

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <module>context-propagation-api</module>
         <module>context-propagation-core</module>
 
+        <module>managers/context-manager-grpc</module>
         <module>managers/context-manager-locale</module>
         <module>managers/context-manager-log4j2</module>
         <module>managers/context-manager-opentelemetry</module>

--- a/readme.md
+++ b/readme.md
@@ -116,6 +116,7 @@ out of the box by this context-propagation library:
 - [Spring Security Context]
 - [OpenTelemetry Context][opentelemetry context propagation]
 - [SLF4J MDC (Mapped Diagnostic Context)][slf4j mdc propagation]
+- [gRPC Context](managers/context-manager-grpc)
 - [Log4j 2 Thread Context][log4j2 thread context propagation]
 - [Locale context][locale context]
 - [ServletRequest contexts][servletrequest propagation]
@@ -192,45 +193,25 @@ and the structure of the repository.
 [Apache 2.0 license](LICENSE)
 
 
-[maven-img]: https://img.shields.io/maven-central/v/nl.talsmasoftware.context/context-propagation
+  [maven-img]: https://img.shields.io/maven-central/v/nl.talsmasoftware.context/context-propagation
+  [maven]: https://search.maven.org/search?q=g:nl.talsmasoftware.context
+  [release-img]: https://img.shields.io/github/release/talsma-ict/context-propagation.svg
+  [release]: https://github.com/talsma-ict/context-propagation/releases
+  [coveralls-img]: https://coveralls.io/repos/github/talsma-ict/context-propagation/badge.svg
+  [coveralls]: https://coveralls.io/github/talsma-ict/context-propagation
+  [javadoc-img]: https://www.javadoc.io/badge/nl.talsmasoftware.context/context-propagation.svg
+  [javadoc]: https://www.javadoc.io/doc/nl.talsmasoftware.context/context-propagation
 
-[maven]: https://search.maven.org/search?q=g:nl.talsmasoftware.context
-
-[release-img]: https://img.shields.io/github/release/talsma-ict/context-propagation.svg
-
-[release]: https://github.com/talsma-ict/context-propagation/releases
-
-[coveralls-img]: https://coveralls.io/repos/github/talsma-ict/context-propagation/badge.svg
-
-[coveralls]: https://coveralls.io/github/talsma-ict/context-propagation
-
-[javadoc-img]: https://www.javadoc.io/badge/nl.talsmasoftware.context/context-propagation.svg
-
-[javadoc]: https://www.javadoc.io/doc/nl.talsmasoftware.context/context-propagation
-
-
-[locale context]: managers/context-manager-locale
-
-[log4j2 thread context propagation]: managers/context-manager-log4j2
-
-[opentelemetry context propagation]: managers/context-manager-opentelemetry
-
-[opentracing span propagation]: managers/context-manager-opentracing
-
-[serviceloader]: https://docs.oracle.com/javase/8/docs/api/index.html?java/util/ServiceLoader.html
-
-[servletrequest propagation]: managers/context-manager-servletrequest
-
-[slf4j mdc propagation]: managers/context-manager-slf4j
-
-[spring security context]: managers/context-manager-spring-security
-
-[context propagation metrics]: timers/context-timer-metrics
-
-[context propagation micrometer]: timers/context-timer-micrometer
-
-[micrometer]: https://micrometer.io
-
-[ContextAwareExecutorService]: https://javadoc.io/doc/nl.talsmasoftware.context/context-propagation/latest/nl/talsmasoftware/context/core/concurrent/ContextAwareExecutorService.html
-
-[ContextAwareCompletableFuture]: context-propagation-core/README.md#contextawarecompletablefuture
+  [locale context]: managers/context-manager-locale
+  [log4j2 thread context propagation]: managers/context-manager-log4j2
+  [opentelemetry context propagation]: managers/context-manager-opentelemetry
+  [opentracing span propagation]: managers/context-manager-opentracing
+  [serviceloader]: https://docs.oracle.com/javase/8/docs/api/index.html?java/util/ServiceLoader.html
+  [servletrequest propagation]: managers/context-manager-servletrequest
+  [slf4j mdc propagation]: managers/context-manager-slf4j
+  [spring security context]: managers/context-manager-spring-security
+  [context propagation metrics]: timers/context-timer-metrics
+  [context propagation micrometer]: timers/context-timer-micrometer
+  [micrometer]: https://micrometer.io
+  [ContextAwareExecutorService]: https://javadoc.io/doc/nl.talsmasoftware.context/context-propagation/latest/nl/talsmasoftware/context/core/concurrent/ContextAwareExecutorService.html
+  [ContextAwareCompletableFuture]: context-propagation-core/README.md#contextawarecompletablefuture


### PR DESCRIPTION
This propagates (and reactivates) ContextSnapshots _over_ gRPC Context, but _also_ propagates gRPC Context _in_ captured ContextSnapshots.

So either method (gRPC Context or ContextSnapshot) will propagate both types of context.

This PR fixes #162.